### PR TITLE
docs: Update README.md with Filecoin Storage Providers Market Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository contains all the code and related artifacts to process Filecoin 
 - [Filecoin In Numbers](https://numbers.filecoindataportal.xyz/)
 - [Filecoin Pulse Website](https://pulse.filecoindataportal.xyz/)
 - [Filecoin Metrics Dune Dashboard](https://dune.com/kalen/filecoin-daily-metrics)
+- [Filecoin Storage Providers Market Dashboard](https://filecoin-project.github.io/filecoin-storage-providers-market/)
 
 ## 🛠️ Contributing
 


### PR DESCRIPTION
Add another example of how this data is being used for public dashboards.

This came to mind while looking at https://github.com/FilOzone/pdp/issues/98