### PR TITLE
fix(apis): only traverse json block in spark car requests

### DIFF
--- a/fdp/apis/spark_assets.py
+++ b/fdp/apis/spark_assets.py
@@ -65,7 +65,7 @@ def raw_spark_retrievals_onchain_data(
 
             context.log.info(f"Fetching CAR for CID {cid}, index {cid_info['index']}")
 
-            url = f"https://{cid}.ipfs.w3s.link/?format=car"
+            url = f"https://{cid}.ipfs.w3s.link/?format=car&dag-scope=block"
 
             try:
                 response = httpx_api.get(url, timeout=300)


### PR DESCRIPTION
# Goals

As I read your code, when you fetch spark CAR file SPARK data, you're only looking for the root json block. You don't intend to fetch all the individual files referred to by the CIDs in that JSON block, which actually reference seperate uplaods to Storacha. 

A few weeks ago, we shipped a fix that actually allowed our fetcher to traverse from one upload to another in a single download. The default `dag-scope` for a car file download per the HTTP trustless spec is to traverse a dag infinitely to its leaves. Prior to the fix we shipped, your download ended we weren't able to traverse across uploads when traversing the DAG in the root block. This had the effect of giving you the `dag-scope` you actually want, which is `block`. However, now that we traverse across uploads, you need to explicitly tell the gateway you want `dag-scope=block` so it doesn't read all the individual uploads referenced in the dag-json root block.

I believe this will fix your slow download.