### PR TITLE
📈 Add FIL metrics visualizations to KPIs dashboard

### DIFF
--- a/numbers/src/kpis.md
+++ b/numbers/src/kpis.md
@@ -26,7 +26,7 @@ const metrics = am.filter(d => {
 ```js
 movingAverageLinePlot({
   metrics,
-  title: "Sector Onboarding",
+  title: "Daily Data Onboarding",
   subtitle: "How much raw power was onboarded to the network at a given time.",
   yField: "sector_onboarding_raw_power_pibs",
   yLabel: "PiBs",
@@ -79,6 +79,51 @@ movingAverageLinePlot({
   showArea: true,
   marks: [
     Plot.ruleY([1000], {
+      stroke: "var(--theme-blue)",
+      strokeWidth: 2,
+      strokeDasharray: "4 4"
+    })
+  ]
+})
+```
+
+</div>
+
+<div class="card">
+
+```js
+movingAverageLinePlot({
+  metrics,
+  title: "Total FIL in Paid Deals",
+  subtitle: "Total FIL in paid deals on the network.",
+  yField: "deal_storage_cost_fil",
+  yLabel: "FIL",
+  showArea: true,
+  marks: [
+    Plot.ruleY([100], {
+      stroke: "var(--theme-blue)",
+      strokeWidth: 2,
+      strokeDasharray: "4 4"
+    })
+  ]
+})
+```
+
+</div>
+
+<div class="card">
+
+```js
+movingAverageLinePlot({
+  metrics,
+  title: "Total Value Flow",
+  subtitle: "Total value flow on the network.",
+  yField: (d) => d.total_value_fil + d.total_gas_used_millions,
+  yLabel: "FIL (Millions)",
+  yTransform: (d) => d / 1e6,
+  showArea: true,
+  marks: [
+    Plot.ruleY([100000000], {
       stroke: "var(--theme-blue)",
       strokeWidth: 2,
       strokeDasharray: "4 4"


### PR DESCRIPTION
## Summary
- Add two new FIL-related visualizations to the KPIs dashboard
- Update sector onboarding chart title for better clarity

## Changes
- Add "Total FIL in Paid Deals" chart showing deal storage costs over time
- Add "Total Value Flow" chart combining total value FIL and gas used (in millions)
- Update "Sector Onboarding" title to "Daily Data Onboarding" for improved clarity
- Include reference lines for key thresholds in the new charts

## Test plan
- [ ] Verify KPIs dashboard loads correctly
- [ ] Confirm new charts render with appropriate data
- [ ] Check that reference lines display at expected values
- [ ] Ensure tooltips and interactions work properly

🤖 Generated with [Claude Code](https://claude.ai/code)