### PR TITLE
📈 Add mining yield visualization to dashboard

### DIFF
--- a/numbers/src/index.md
+++ b/numbers/src/index.md
@@ -806,6 +806,21 @@ movingAverageLinePlot({
 ```
 </div>
 
+<div class="card" id="mining-yield">
+
+```js
+movingAverageLinePlot({
+  metrics: metrics.map(d => ({...d, mining_yield: d.locked_fil > 0 ? (d.mined_fil_delta / d.locked_fil) * 100 * 365 : 0})),
+  title: title_anchor("Mining Yield", "mining-yield"),
+  subtitle: "Pure yield through time. Daily mined FIL relative to locked FIL, annualized.",
+  caption: "Shows the annualized percentage return on locked tokens. Displaying 30-day moving average.",
+  yField: "mining_yield",
+  yLabel: "Annual Yield (%)",
+  showArea: true
+})
+```
+</div>
+
 <div class="card" id="vested-fil">
 
 ```js


### PR DESCRIPTION
## Summary
- Added new mining yield chart to the dashboard
- Shows annualized percentage return on locked tokens over time
- Displays 30-day moving average for better trend visibility

## Test plan
- [ ] Verify the chart renders correctly
- [ ] Check that the mining yield calculation is accurate (daily mined FIL / locked FIL * 100 * 365)
- [ ] Confirm the 30-day moving average displays properly