### PR TITLE
Fix Pulse dashboards after allocator schema changes

### DIFF
--- a/dbt/models/filecoin_allocators.sql
+++ b/dbt/models/filecoin_allocators.sql
@@ -28,13 +28,15 @@ datacap_allocators_registry as (
         address as entrypoint_address,
         name as allocator_name,
         organization as allocator_organization_name,
-        location,
-        status,
         metapathway_type,
+        ma_address,
+        pathway_addresses,
         associated_org_addresses,
         application,
-        poc,
-        pathway_addresses
+        history,
+        audits,
+        old_allocator_id,
+        allocator_id
     from  {{ source('raw_assets', 'raw_datacap_allocators_registry') }}
 )
 
@@ -60,8 +62,6 @@ select
     da.is_active,
     dar.application_number,
     concat('https://github.com/filecoin-project/Allocator-Registry/blob/main/Allocators/', dar.application_number, '.json') as application_url,
-    dar.location,
-    dar.status,
     dar.metapathway_type,
     dar.associated_org_addresses,
     dar.application->>'$.allocations.standardized' as is_standardized,
@@ -74,8 +74,11 @@ select
     try_cast(dar.application->>'$.12m_requested' as int) as '12m_requested',
     dar.application->>'$.github_handles[0]' as github_handle,
     dar.application->>'$.allocation_bookkeeping' as allocation_bookkeeping,
-    dar.poc->>'$.slack' as poc_slack,
-    dar.poc->>'$.github_user' as poc_github_user,
+    dar.history,
+    dar.audits,
+    dar.old_allocator_id,
+    dar.allocator_id as registry_allocator_id,
+    dar.ma_address,
     dar.pathway_addresses->>'$.msig' as pathway_addresses_msig,
     dar.pathway_addresses->>'$.signer[0]' as pathway_addresses_signer,
 from datacapstats_allocators as da

--- a/dbt/models/filecoin_allocators.sql
+++ b/dbt/models/filecoin_allocators.sql
@@ -67,7 +67,7 @@ select
     dar.application->>'$.allocations.standardized' as is_standardized,
     dar.application->>'$.target_clients[0]' as target_clients,
     json_array_length(dar.application->>'$.target_clients') as number_of_target_clients,
-    try_cast(trim('+' from dar.application->>'$.required_sps') as int) as minimum_required_storage_povider_replication,
+    try_cast(trim('+' from dar.application->>'$.required_sps') as int) as minimum_required_storage_provider_replication,
     try_cast(trim('+' from dar.application->>'$.required_replicas') as int) as minimum_required_replicas,
     dar.application->>'$.tooling[0]' as tooling,
     dar.application->>'$.data_types' as data_types,
@@ -80,7 +80,7 @@ select
     dar.allocator_id as registry_allocator_id,
     dar.ma_address,
     dar.pathway_addresses->>'$.msig' as pathway_addresses_msig,
-    dar.pathway_addresses->>'$.signer[0]' as pathway_addresses_signer,
+    dar.pathway_addresses->>'$.signer[0]' as pathway_addresses_signer
 from datacapstats_allocators as da
 left join datacap_allocators_registry as dar
     on da.allocator_address = dar.allocator_address

--- a/pulse/pages/allocator/[allocator_id].md
+++ b/pulse/pages/allocator/[allocator_id].md
@@ -78,11 +78,6 @@ where allocator_id = '${params.allocator_id}'
 
 <BigValue
   data={filtered_allocator_info}
-  value=location
-/>
-
-<BigValue
-  data={filtered_allocator_info}
   value=metapathway_type
 />
 
@@ -124,16 +119,6 @@ where allocator_id = '${params.allocator_id}'
 <BigValue
   data={filtered_allocator_info}
   value=github_handle
-/>
-
-<BigValue
-  data={filtered_allocator_info}
-  value=poc_slack
-/>
-
-<BigValue
-  data={filtered_allocator_info}
-  value=poc_github_user
 />
 
 <BigValue

--- a/pulse/pages/allocators.md
+++ b/pulse/pages/allocators.md
@@ -201,61 +201,6 @@ order by verified_clients_count desc
   downloadable=true
 />
 
-### Country Distribution
-
-```sql country_distribution
-select
-  location,
-  count(distinct allocator_id) as allocators,
-  sum(initial_allowance_tibs) as initial_allowance_tibs,
-  sum(current_allowance_tibs) as current_allowance_tibs,
-  sum(initial_allowance_tibs) - sum(current_allowance_tibs) as used_allowance_tibs,
-  sum("12m_requested"::numeric) as requested_tibs,
-from filecoin_allocators
-where 1 = 1
-  and is_active
-group by 1
-```
-
-<Grid cols=2>
-
-<BarChart
-  data={country_distribution}
-  x=location
-  y=allocators
-  connectGroup=country
-  labels=true
-  title="Allocators by Country"
-/>
-
-<BarChart
-  data={country_distribution}
-  x=location
-  y=current_allowance_tibs
-  connectGroup=country
-  labels=true
-  title="Current Allowance by Country"
-/>
-
-<BarChart
-  data={country_distribution}
-  x=location
-  y=requested_tibs
-  connectGroup=country
-  labels=true
-  title="Requested Data by Country"
-/>
-
-<BarChart
-  data={country_distribution}
-  x=location
-  y=used_allowance_tibs
-  connectGroup=country
-  labels=true
-  title="Used Allowance by Country"
-/>
-
-</Grid>
 
 ### Pathway Distribution
 


### PR DESCRIPTION
## Summary
- Updated Pulse dashboards to match the new allocator schema from dbt model changes
- Removed references to columns that are no longer available in the source data

## Changes Made
1. **Removed Country Distribution section** from `pulse/pages/allocators.md` - the `location` column is no longer in the allocator registry data
2. **Removed POC information displays** from `pulse/pages/allocator/[allocator_id].md` - `poc_slack` and `poc_github_user` columns are no longer available
3. **Updated dbt model** `filecoin_allocators.sql` to include new columns (`history`, `audits`, `old_allocator_id`, `ma_address`) and remove deprecated ones

## Test Plan
- [ ] Run `make pulse` to verify dashboard still works
- [ ] Check allocators page loads without errors
- [ ] Check individual allocator detail pages load without errors