### PR TITLE
Add info alert about deals data on Onramps page

### DIFF
--- a/pulse/pages/onramps.md
+++ b/pulse/pages/onramps.md
@@ -4,6 +4,10 @@ title: Onramps
 
 _A detailed view into Filecoin Onramps._
 
+<Alert status="info">
+  Deals data comes from State Market Deals. DDO deals are not incorporated.
+</Alert>
+
 ```sql onramps_stats
 select
   count(distinct onramp_name) as total_onramps,


### PR DESCRIPTION
## Summary
- add an informational alert to clarify that deals data comes from State Market Deals and excludes DDO deals on the Onramps page

## Testing
- `npm test` (fails: Build process exited with code 1; table `filecoin_onramps` does not exist)


------
https://chatgpt.com/codex/tasks/task_e_68b579df4704832ea9d202f5a06d3b71