### PR TITLE
🎨 Consolidate onramp data disclaimers into one alert

### DIFF
--- a/pulse/pages/onramp/[onramp_name].md
+++ b/pulse/pages/onramp/[onramp_name].md
@@ -1,5 +1,9 @@
 # {$page.params.onramp_name}
 
+<Alert status="info">
+  Metrics shown here are derived solely from on-chain sector data. Some onramps may self-deal, pad sectors, or perform pre/post activities that are not visible in this dataset. Deals data comes from State Market Deals and excludes DDO deals.
+</Alert>
+
 <DateRange
   name=range
   start=2023-01-01

--- a/pulse/pages/onramps.md
+++ b/pulse/pages/onramps.md
@@ -4,6 +4,10 @@ title: Onramps
 
 _A detailed view into Filecoin Onramps._
 
+<Alert status="info">
+  These comparisons rely solely on on-chain sector data. Some onramps may self-deal, pad sectors, or perform other pre/post activities that are not captured here. Deals data comes from State Market Deals and excludes DDO deals.
+</Alert>
+
 ```sql onramps_stats
 select
   count(distinct onramp_name) as total_onramps,


### PR DESCRIPTION
## Summary
- merge sector and deal data caveats into a single info alert on onramp overview and detail pages

## Testing
- `npm run sources --prefix pulse` *(fails: Extension Autoloading Error: could not download httpfs)*
- `npm test --prefix pulse` *(fails: No sources found; execute "npm run sources" to generate)*

------
https://chatgpt.com/codex/tasks/task_e_68b579140d5c832e9e48e6e374fc1157