### PR TITLE
Add WBR text under KPI charts

### DIFF
--- a/numbers/src/kpis.md
+++ b/numbers/src/kpis.md
@@ -14,6 +14,98 @@ const am = await FileAttachment("./data/daily_metrics.csv").csv({typed: true});
 ```
 
 ```js
+// Goals used for rule lines and WBR snippets
+// Note: keep these in sync with the visual thresholds in the charts below.
+// If the WBR goals change, update only here.
+const KPI_GOALS = {
+  dataOnboardingPiBPerDay: 5,            // PiB/day
+  clientsGt1TiB: 1000,                   // clients
+  paidDealsFilPerDay: 100,               // FIL/day
+  valueFlowFilPerDay: 100_000_000        // FIL/day (displayed as millions of FIL)
+};
+
+// Date helpers (ISO week: Monday-Sunday) anchored to latest available metric date
+function startOfISOWeekUTC(d) {
+  const dt = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = dt.getUTCDay(); // 0=Sun,1=Mon,...
+  const diff = day === 0 ? -6 : 1 - day; // shift to Monday
+  dt.setUTCDate(dt.getUTCDate() + diff);
+  dt.setUTCHours(0, 0, 0, 0);
+  return dt;
+}
+
+function addDaysUTC(d, days) {
+  const r = new Date(d); r.setUTCDate(r.getUTCDate() + days); return r;
+}
+
+// Compute averages over date windows using a field accessor
+function averageOver(metrics, fromInclusive, toExclusive, accessor) {
+  const vals = metrics
+    .filter((row) => row.date >= fromInclusive && row.date < toExclusive)
+    .map(accessor)
+    .filter((v) => Number.isFinite(v));
+  if (!vals.length) return NaN;
+  return vals.reduce((a, b) => a + b, 0) / vals.length;
+}
+
+function latestDateIn(series) {
+  let max = new Date(0);
+  for (const d of series) if (d.date > max) max = d.date;
+  return max;
+}
+
+function weeklyAverages(metrics, accessor) {
+  const latest = latestDateIn(metrics);
+  const thisWeekStart = startOfISOWeekUTC(latest);
+  const nextWeekStart = addDaysUTC(thisWeekStart, 7);
+  const lastWeekStart = addDaysUTC(thisWeekStart, -7);
+  const thirteenWeeksStart = addDaysUTC(thisWeekStart, -13 * 7);
+
+  const thisWeek = averageOver(metrics, thisWeekStart, nextWeekStart, accessor);
+  const lastWeek = averageOver(metrics, lastWeekStart, thisWeekStart, accessor);
+  const avg13w = averageOver(metrics, thirteenWeeksStart, thisWeekStart, accessor);
+  return { thisWeek, lastWeek, avg13w, thisWeekStart };
+}
+
+// Formatting helpers
+const fmt = (n, d=1) => Number.isFinite(n) ? n.toLocaleString(undefined, {maximumFractionDigits: d, minimumFractionDigits: d}) : "n/a";
+const fmtInt = (n) => Number.isFinite(n) ? Math.round(n).toLocaleString() : "n/a";
+const fmtMillions = (n, d=1) => Number.isFinite(n) ? (n/1e6).toLocaleString(undefined, {maximumFractionDigits: d, minimumFractionDigits: d}) : "n/a";
+const fmtSigned = (n, d=1) => Number.isFinite(n) ? `${n >= 0 ? "+" : ""}${n.toLocaleString(undefined, {maximumFractionDigits: d, minimumFractionDigits: d})}` : "n/a";
+const fmtSignedMillions = (n, d=1) => Number.isFinite(n) ? `${n >= 0 ? "+" : ""}${(n/1e6).toLocaleString(undefined, {maximumFractionDigits: d, minimumFractionDigits: d})}` : "n/a";
+
+function kpiSnippet({
+  accessor,
+  goal,
+  unit = "",            // e.g., "PiB", "FIL", "clients"
+  showMillions = false,  // if true, display values and goal in millions
+  decimals = 1,          // decimals for non-integer formatting
+  integer = false        // integer formatting (e.g., clients)
+}) {
+  const { thisWeek, lastWeek, avg13w, thisWeekStart } = weeklyAverages(metrics, accessor);
+  const wow = thisWeek - lastWeek;
+  const gapThis = thisWeek - goal;
+  const gap13 = avg13w - goal;
+
+  const weekStr = thisWeekStart.toISOString().slice(0,10); // anchor for debugging/context if needed
+
+  const v = (n) => integer ? fmtInt(n) : (showMillions ? fmtMillions(n, decimals) : fmt(n, decimals));
+  const g = showMillions ? fmtMillions(goal, decimals) : (integer ? fmtInt(goal) : fmt(goal, decimals));
+  const wowStr = integer ? fmtSigned(wow, 0) : (showMillions ? fmtSignedMillions(wow, decimals) : fmtSigned(wow, decimals));
+  const gapThisStr = integer ? fmtSigned(gapThis, 0) : (showMillions ? fmtSignedMillions(gapThis, decimals) : fmtSigned(gapThis, decimals));
+  const gap13Str = integer ? fmtSigned(gap13, 0) : (showMillions ? fmtSignedMillions(gap13, decimals) : fmtSigned(gap13, decimals));
+  const unitStr = unit ? ` ${unit}` : "";
+
+  const gapThisCls = gapThis >= 0 ? 'delta-pos' : 'delta-neg';
+  const wowCls = wow >= 0 ? 'delta-pos' : 'delta-neg';
+  const gap13Cls = gap13 >= 0 ? 'delta-pos' : 'delta-neg';
+
+  // Single-line markup, no extra whitespace around parentheses
+  return htl.html`<p class="kpi-snippet"><strong>${v(thisWeek)}${unitStr}</strong> this week vs <strong>${g}${unitStr}</strong> goal (<span class="${gapThisCls}"><strong>${gapThisStr}${unitStr}</strong></span> gap), last week <strong>${v(lastWeek)}${unitStr}</strong> (<span class="${wowCls}"><strong>${wowStr}${unitStr}</strong></span> WoW change), 13-wk average <strong>${v(avg13w)}${unitStr}</strong> vs <strong>${g}${unitStr}</strong> goal (<span class="${gap13Cls}"><strong>${gap13Str}${unitStr}</strong></span> gap).</p>`;
+}
+```
+
+```js
 const metrics = am.filter(d => {
   const oneYearAgo = new Date();
   oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
@@ -32,7 +124,7 @@ movingAverageLinePlot({
   yLabel: "PiBs",
   showArea: true,
   marks: [
-    Plot.ruleY([5], {
+    Plot.ruleY([KPI_GOALS.dataOnboardingPiBPerDay], {
       stroke: "var(--theme-blue)",
       strokeWidth: 2,
       strokeDasharray: "4 4"
@@ -40,7 +132,16 @@ movingAverageLinePlot({
   ]
 })
 ```
+---
 
+```js
+kpiSnippet({
+  accessor: (d) => d.sector_onboarding_raw_power_pibs,
+  goal: KPI_GOALS.dataOnboardingPiBPerDay,
+  unit: "PiB",
+  decimals: 1
+})
+```
 </div>
 
 <div class="card">
@@ -54,12 +155,22 @@ movingAverageLinePlot({
   yLabel: "Number of Clients",
   showArea: true,
   marks: [
-    Plot.ruleY([1000], {
+    Plot.ruleY([KPI_GOALS.clientsGt1TiB], {
       stroke: "var(--theme-blue)",
       strokeWidth: 2,
       strokeDasharray: "4 4"
     })
   ]
+})
+```
+
+---
+
+```js
+kpiSnippet({
+  accessor: (d) => d.clients_with_active_data_gt_1_tibs,
+  goal: KPI_GOALS.clientsGt1TiB,
+  integer: true
 })
 ```
 
@@ -76,12 +187,23 @@ movingAverageLinePlot({
   yLabel: "FIL",
   showArea: true,
   marks: [
-    Plot.ruleY([100], {
+    Plot.ruleY([KPI_GOALS.paidDealsFilPerDay], {
       stroke: "var(--theme-blue)",
       strokeWidth: 2,
       strokeDasharray: "4 4"
     })
   ]
+})
+```
+
+---
+
+```js
+kpiSnippet({
+  accessor: (d) => d.deal_storage_cost_fil,
+  goal: KPI_GOALS.paidDealsFilPerDay,
+  unit: "FIL",
+  decimals: 1
 })
 ```
 
@@ -99,12 +221,24 @@ movingAverageLinePlot({
   yTransform: (d) => d / 1e6,
   showArea: true,
   marks: [
-    Plot.ruleY([100000000], {
+    Plot.ruleY([KPI_GOALS.valueFlowFilPerDay], {
       stroke: "var(--theme-blue)",
       strokeWidth: 2,
       strokeDasharray: "4 4"
     })
   ]
+})
+```
+
+---
+
+```js
+kpiSnippet({
+  accessor: (d) => d.total_value_fil + d.total_gas_used_millions,
+  goal: KPI_GOALS.valueFlowFilPerDay,
+  unit: "M FIL",
+  showMillions: true,
+  decimals: 1
 })
 ```
 

--- a/numbers/src/style.css
+++ b/numbers/src/style.css
@@ -156,3 +156,10 @@ aside#observablehq-toc {
 .card:target {
     border: 4px solid var(--theme-blue);
 }
+
+/* WBR snippets below charts */
+.kpi-snippet {
+    color: var(--theme-foreground-muted);
+    font-size: 0.95rem;
+    margin: 0.5rem 0 1rem 0;
+}

--- a/numbers/src/style.css
+++ b/numbers/src/style.css
@@ -162,4 +162,13 @@ aside#observablehq-toc {
     color: var(--theme-foreground-muted);
     font-size: 0.95rem;
     margin: 0.5rem 0 1rem 0;
+    max-width: none; /* allow full card width */
+    width: 100%;
 }
+
+.kpi-snippet strong { font-weight: 600; }
+.kpi-snippet .delta-pos { color: var(--theme-green); }
+.kpi-snippet .delta-neg { color: var(--theme-red); }
+
+/* ensure normal spacing for inline text */
+.kpi-snippet { letter-spacing: normal; word-spacing: normal; }


### PR DESCRIPTION
This PR adds lightweight WBR snippets under the four KPI charts in Numbers.\n\nWhat’s included\n- Compute ISO week (Mon–Sun) averages anchored to the latest metric date: this week (WTD), last week, and 13‑week average.\n- Centralize targets in  and reuse them for chart rule lines + text.\n- Render single‑line snippets inside each card (after a  separator) with: this week vs goal (gap), last week (WoW), and 13‑wk avg vs goal (gap).\n- Improved readability: full‑width line, bold key figures, subtle green/red for deltas.\n- Millions formatting for value‑flow KPI (e.g., ), including WoW and gaps.\n\nNotes\n- Goals are placeholders taken from existing rule lines. Update them in one place () if targets change.\n- If you prefer last completed week instead of WTD, I can switch the windowing.\n\nValidation\n- Built locally with 
> build
> observable build

load /index in 322ms
load /kpis-xmr in 26ms
load /kpis in 24ms
built 3 pages in src
bundle /_observablehq/client.js → src/.observablehq/cache/_observablehq/client.js
bundle /_observablehq/runtime.js → src/.observablehq/cache/_observablehq/runtime.js
bundle /_observablehq/stdlib.js → src/.observablehq/cache/_observablehq/stdlib.js
bundle /_observablehq/stdlib/inputs.js → src/.observablehq/cache/_observablehq/stdlib/inputs.js
build src/style.css → dist/_import/style.97e9f073.css
build /_observablehq/stdlib/inputs.css → dist/_observablehq/stdlib/inputs.ea9fd553.css
copy src/logo.svg → dist/_file/logo.bc86ddd5.svg
copy src/data/daily_metrics.csv → load /data/daily_metrics.csv → [fresh] success 1.91 MB in 3ms
dist/_file/data/daily_metrics.7380b361.csv
copy src/data/daily_region_metrics.csv → load /data/daily_region_metrics.csv → [fresh] success 848 kB in 0ms
dist/_file/data/daily_region_metrics.7336e7c1.csv
copy src/data/daily_industry_metrics.csv → load /data/daily_industry_metrics.csv → [fresh] success 792 kB in 0ms
dist/_file/data/daily_industry_metrics.6f4ddcab.csv
copy src/data/daily_transactions.csv → load /data/daily_transactions.csv → [fresh] success 2.52 MB in 0ms
dist/_file/data/daily_transactions.1b74478c.csv
alias /_observablehq/client.js → /_observablehq/client.9e43f334.js
alias /_observablehq/runtime.js → /_observablehq/runtime.e080113b.js
alias /_observablehq/stdlib.js → /_observablehq/stdlib.82806664.js
alias /_npm/htl@0.3.1/_esm.js → /_npm/htl@0.3.1/72f4716c.js
alias /_observablehq/stdlib/inputs.js → /_observablehq/stdlib/inputs.6ba3de0b.js
alias /_npm/@observablehq/plot@0.6.17/_esm.js → /_npm/@observablehq/plot@0.6.17/d761ef9b.js
alias /_npm/d3-dsv@3.0.1/_esm.js → /_npm/d3-dsv@3.0.1/9cffc2bd.js
alias /_npm/isoformat@0.2.1/_esm.js → /_npm/isoformat@0.2.1/18cbf477.js
alias /_npm/d3@7.9.0/_esm.js → /_npm/d3@7.9.0/e780feca.js
alias /_npm/interval-tree-1d@1.0.4/_esm.js → /_npm/interval-tree-1d@1.0.4/53fe8176.js
alias /_npm/d3-array@3.2.4/_esm.js → /_npm/d3-array@3.2.4/e93ca09f.js
alias /_npm/d3-axis@3.0.0/_esm.js → /_npm/d3-axis@3.0.0/0f2de24d.js
alias /_npm/d3-brush@3.0.0/_esm.js → /_npm/d3-brush@3.0.0/65eb105b.js
alias /_npm/d3-chord@3.0.1/_esm.js → /_npm/d3-chord@3.0.1/7ef8fb2e.js
alias /_npm/d3-color@3.1.0/_esm.js → /_npm/d3-color@3.1.0/aeb57b94.js
alias /_npm/d3-contour@4.0.2/_esm.js → /_npm/d3-contour@4.0.2/1d2aed74.js
alias /_npm/d3-delaunay@6.0.4/_esm.js → /_npm/d3-delaunay@6.0.4/5ced1d52.js
alias /_npm/d3-dispatch@3.0.1/_esm.js → /_npm/d3-dispatch@3.0.1/9ba9c7f3.js
alias /_npm/d3-drag@3.0.0/_esm.js → /_npm/d3-drag@3.0.0/4202580c.js
alias /_npm/d3-ease@3.0.1/_esm.js → /_npm/d3-ease@3.0.1/cdd7e898.js
alias /_npm/d3-fetch@3.0.1/_esm.js → /_npm/d3-fetch@3.0.1/b4e2ad9a.js
alias /_npm/d3-force@3.0.0/_esm.js → /_npm/d3-force@3.0.0/5e804d15.js
alias /_npm/d3-format@3.1.0/_esm.js → /_npm/d3-format@3.1.0/86074ef6.js
alias /_npm/d3-geo@3.1.1/_esm.js → /_npm/d3-geo@3.1.1/40599fb3.js
alias /_npm/d3-hierarchy@3.1.2/_esm.js → /_npm/d3-hierarchy@3.1.2/e49e792c.js
alias /_npm/d3-interpolate@3.0.1/_esm.js → /_npm/d3-interpolate@3.0.1/8d1e5425.js
alias /_npm/d3-path@3.1.0/_esm.js → /_npm/d3-path@3.1.0/20d3f133.js
alias /_npm/d3-polygon@3.0.1/_esm.js → /_npm/d3-polygon@3.0.1/7553081f.js
alias /_npm/d3-quadtree@3.0.1/_esm.js → /_npm/d3-quadtree@3.0.1/0dfd751c.js
alias /_npm/d3-random@3.0.1/_esm.js → /_npm/d3-random@3.0.1/3c90ee06.js
alias /_npm/d3-scale@4.0.2/_esm.js → /_npm/d3-scale@4.0.2/843b6a76.js
alias /_npm/d3-scale-chromatic@3.1.0/_esm.js → /_npm/d3-scale-chromatic@3.1.0/ba24c2e7.js
alias /_npm/d3-selection@3.0.0/_esm.js → /_npm/d3-selection@3.0.0/4d94e5b7.js
alias /_npm/d3-shape@3.2.0/_esm.js → /_npm/d3-shape@3.2.0/6d3a6726.js
alias /_npm/d3-time@3.1.0/_esm.js → /_npm/d3-time@3.1.0/9f03c579.js
alias /_npm/d3-time-format@4.1.0/_esm.js → /_npm/d3-time-format@4.1.0/07c9626f.js
alias /_npm/d3-timer@3.0.1/_esm.js → /_npm/d3-timer@3.0.1/b58a267d.js
alias /_npm/d3-transition@3.0.1/_esm.js → /_npm/d3-transition@3.0.1/004da2ac.js
alias /_npm/d3-zoom@3.0.0/_esm.js → /_npm/d3-zoom@3.0.0/b5786b3f.js
alias /_npm/binary-search-bounds@2.0.5/_esm.js → /_npm/binary-search-bounds@2.0.5/cbf6ba23.js
alias /_npm/internmap@2.0.3/_esm.js → /_npm/internmap@2.0.3/e08981d9.js
alias /_npm/delaunator@5.0.1/_esm.js → /_npm/delaunator@5.0.1/02d43215.js
alias /_npm/robust-predicates@3.0.2/_esm.js → /_npm/robust-predicates@3.0.2/aa00730b.js
build /_observablehq/client.js → dist/_observablehq/client.9e43f334.js
build /_observablehq/runtime.js → dist/_observablehq/runtime.e080113b.js
build /_observablehq/stdlib.js → dist/_observablehq/stdlib.82806664.js
build /_npm/htl@0.3.1/_esm.js → dist/_npm/htl@0.3.1/72f4716c.js
build /_observablehq/stdlib/inputs.js → dist/_observablehq/stdlib/inputs.6ba3de0b.js
build /_npm/@observablehq/plot@0.6.17/_esm.js → dist/_npm/@observablehq/plot@0.6.17/d761ef9b.js
build /_npm/d3-dsv@3.0.1/_esm.js → dist/_npm/d3-dsv@3.0.1/9cffc2bd.js
build /_npm/isoformat@0.2.1/_esm.js → dist/_npm/isoformat@0.2.1/18cbf477.js
build /_npm/d3@7.9.0/_esm.js → dist/_npm/d3@7.9.0/e780feca.js
build /_npm/interval-tree-1d@1.0.4/_esm.js → dist/_npm/interval-tree-1d@1.0.4/53fe8176.js
build /_npm/d3-array@3.2.4/_esm.js → dist/_npm/d3-array@3.2.4/e93ca09f.js
build /_npm/d3-axis@3.0.0/_esm.js → dist/_npm/d3-axis@3.0.0/0f2de24d.js
build /_npm/d3-brush@3.0.0/_esm.js → dist/_npm/d3-brush@3.0.0/65eb105b.js
build /_npm/d3-chord@3.0.1/_esm.js → dist/_npm/d3-chord@3.0.1/7ef8fb2e.js
build /_npm/d3-color@3.1.0/_esm.js → dist/_npm/d3-color@3.1.0/aeb57b94.js
build /_npm/d3-contour@4.0.2/_esm.js → dist/_npm/d3-contour@4.0.2/1d2aed74.js
build /_npm/d3-delaunay@6.0.4/_esm.js → dist/_npm/d3-delaunay@6.0.4/5ced1d52.js
build /_npm/d3-dispatch@3.0.1/_esm.js → dist/_npm/d3-dispatch@3.0.1/9ba9c7f3.js
build /_npm/d3-drag@3.0.0/_esm.js → dist/_npm/d3-drag@3.0.0/4202580c.js
build /_npm/d3-ease@3.0.1/_esm.js → dist/_npm/d3-ease@3.0.1/cdd7e898.js
build /_npm/d3-fetch@3.0.1/_esm.js → dist/_npm/d3-fetch@3.0.1/b4e2ad9a.js
build /_npm/d3-force@3.0.0/_esm.js → dist/_npm/d3-force@3.0.0/5e804d15.js
build /_npm/d3-format@3.1.0/_esm.js → dist/_npm/d3-format@3.1.0/86074ef6.js
build /_npm/d3-geo@3.1.1/_esm.js → dist/_npm/d3-geo@3.1.1/40599fb3.js
build /_npm/d3-hierarchy@3.1.2/_esm.js → dist/_npm/d3-hierarchy@3.1.2/e49e792c.js
build /_npm/d3-interpolate@3.0.1/_esm.js → dist/_npm/d3-interpolate@3.0.1/8d1e5425.js
build /_npm/d3-path@3.1.0/_esm.js → dist/_npm/d3-path@3.1.0/20d3f133.js
build /_npm/d3-polygon@3.0.1/_esm.js → dist/_npm/d3-polygon@3.0.1/7553081f.js
build /_npm/d3-quadtree@3.0.1/_esm.js → dist/_npm/d3-quadtree@3.0.1/0dfd751c.js
build /_npm/d3-random@3.0.1/_esm.js → dist/_npm/d3-random@3.0.1/3c90ee06.js
build /_npm/d3-scale@4.0.2/_esm.js → dist/_npm/d3-scale@4.0.2/843b6a76.js
build /_npm/d3-scale-chromatic@3.1.0/_esm.js → dist/_npm/d3-scale-chromatic@3.1.0/ba24c2e7.js
build /_npm/d3-selection@3.0.0/_esm.js → dist/_npm/d3-selection@3.0.0/4d94e5b7.js
build /_npm/d3-shape@3.2.0/_esm.js → dist/_npm/d3-shape@3.2.0/6d3a6726.js
build /_npm/d3-time@3.1.0/_esm.js → dist/_npm/d3-time@3.1.0/9f03c579.js
build /_npm/d3-time-format@4.1.0/_esm.js → dist/_npm/d3-time-format@4.1.0/07c9626f.js
build /_npm/d3-timer@3.0.1/_esm.js → dist/_npm/d3-timer@3.0.1/b58a267d.js
build /_npm/d3-transition@3.0.1/_esm.js → dist/_npm/d3-transition@3.0.1/004da2ac.js
build /_npm/d3-zoom@3.0.0/_esm.js → dist/_npm/d3-zoom@3.0.0/b5786b3f.js
build /_npm/binary-search-bounds@2.0.5/_esm.js → dist/_npm/binary-search-bounds@2.0.5/cbf6ba23.js
build /_npm/internmap@2.0.3/_esm.js → dist/_npm/internmap@2.0.3/e08981d9.js
build /_npm/delaunator@5.0.1/_esm.js → dist/_npm/delaunator@5.0.1/02d43215.js
build /_npm/robust-predicates@3.0.2/_esm.js → dist/_npm/robust-predicates@3.0.2/aa00730b.js
copy src/components/movingAverageLinePlot.js → dist/_import/components/movingAverageLinePlot.fd2646ac.js
copy src/components/xmr.js → dist/_import/components/xmr.6087a475.js
render /index → dist/index.html
render /kpis-xmr → dist/kpis-xmr.html
render /kpis → dist/kpis.html

┌ (3 pages)           Page      Imports        Files
├── index            69 kB       623 kB     6.108 MB
├── kpis-xmr          7 kB       591 kB     1.940 MB
└── kpis             15 kB       595 kB     1.940 MB.\n\nScreenshots\n- See local build; happy to attach if needed.