### PR TITLE
Add FIL price ingestion and metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# Local SSH keys for external DB access
+.ssh/
+
 # C extensions
 *.so
 

--- a/dbt/models/sources.yml
+++ b/dbt/models/sources.yml
@@ -164,3 +164,7 @@ sources:
         meta:
           dagster:
             asset_key: ["raw_onramp_mappings"]
+      - name: raw_fil_price
+        meta:
+          dagster:
+            asset_key: ["raw_fil_price"]


### PR DESCRIPTION
Purpose

Add FIL USD price history as a raw Dagster asset and surface it in the periodic metrics models to enable USD‑denominated charts and price/network correlations.

Changes
- Add Dagster asset `raw_fil_price` that fetches historical daily FIL data from CoinCodex and writes to `raw.raw_fil_price`.
- Register dbt source `raw_fil_price`.
- Extend `filecoin_periodic_metrics` macro to join the aggregated price series to each time bucket.
- Ignore local `.ssh/` directory in `.gitignore`.

New Columns in metrics
- `fil_token_price_avg_usd`: average FIL price over the bucket (USD).
- `fil_token_volume_usd`: summed trading volume during the bucket (USD).
- `fil_token_market_cap_usd`: average market cap during the bucket (USD).

How to test locally
1) `uv run dagster asset materialize --select raw_fil_price`
2) `uv run dbt run -s metrics/filecoin_daily_metrics metrics/filecoin_weekly_metrics metrics/filecoin_monthly_metrics`
3) Inspect the three new columns in DuckDB for recent dates.

Notes / risks
- Data source: CoinCodex historical API by slug `filecoin` (unauthenticated). Subject to rate limits; please review TOS before heavy/production use.
- Start date: 2020-01-01; macro buckets are anchored at 2020-10-01.

Open to switching providers (e.g., CoinGecko) or adjusting column names if preferred.
