### PR TITLE
Add FIL price metrics to Numbers dashboard

### DIFF
--- a/numbers/src/data/daily_metrics.csv.sh
+++ b/numbers/src/data/daily_metrics.csv.sh
@@ -105,7 +105,12 @@ COPY (
 
     -- Transactions
     transactions,
-    total_value_fil
+    total_value_fil,
+
+    -- FIL Price (USD)
+    fil_token_price_avg_usd,
+    fil_token_volume_usd,
+    fil_token_market_cap_usd
   FROM read_parquet('https://data.filecoindataportal.xyz/filecoin_daily_metrics.parquet')
 ) TO STDOUT (FORMAT 'CSV');
 EOF

--- a/numbers/src/index.md
+++ b/numbers/src/index.md
@@ -986,6 +986,55 @@ movingAverageLinePlot({
 ```
 </div>
 
+<div class="card" id="fil-token-price">
+
+```js
+movingAverageLinePlot({
+  metrics,
+  title: title_anchor("FIL Token Price", "fil-token-price"),
+  subtitle: "Average daily FIL token price in USD.",
+  yField: "fil_token_price_avg_usd",
+  yLabel: "USD",
+  showArea: true,
+})
+```
+
+</div>
+
+<div class="card" id="fil-token-volume">
+
+```js
+movingAverageLinePlot({
+  metrics,
+  title: title_anchor("FIL Token Volume", "fil-token-volume"),
+  subtitle: "Reported daily FIL token trading volume in USD.",
+  caption: "Displaying 30-day moving average. Values shown in millions of USD.",
+  yField: "fil_token_volume_usd",
+  yLabel: "USD (Millions)",
+  yTransform: (d) => d / 1e6,
+  showArea: true,
+})
+```
+
+</div>
+
+<div class="card" id="fil-token-market-cap">
+
+```js
+movingAverageLinePlot({
+  metrics,
+  title: title_anchor("FIL Token Market Cap", "fil-token-market-cap"),
+  subtitle: "Average daily market capitalization for FIL in USD.",
+  caption: "Displaying 30-day moving average. Values shown in billions of USD.",
+  yField: "fil_token_market_cap_usd",
+  yLabel: "USD (Billions)",
+  yTransform: (d) => d / 1e9,
+  showArea: true,
+})
+```
+
+</div>
+
 <div class="card" id="fil-plus-share">
 
 ```js


### PR DESCRIPTION
## Summary
- extend the daily metrics export to include the new FIL token price, volume, and market cap fields
- surface the FIL token price metrics on the Numbers economics dashboard with three new moving-average charts

## Testing
- npm run build *(fails: observable build cannot fetch npm:htl in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c85e74f4cc832e89233a0503c972aa