### PR TITLE
📈 Update network utilization ratio calculations

### DIFF
--- a/dbt/macros/filecoin_periodic_metrics.sql
+++ b/dbt/macros/filecoin_periodic_metrics.sql
@@ -364,7 +364,8 @@ select
     storage_providers_rewards,
 
     -- Others
-    data_on_active_deals_pibs / raw_power_pibs as network_utilization_ratio,
+    data_on_active_deals_pibs / raw_power_pibs as network_utilization_ratio_state_market_deals,
+    verified_data_power_pibs / raw_power_pibs as network_utilization_ratio,
 
     -- Sector Metrics
     sector_onboarding_count,


### PR DESCRIPTION
Today in the network we have a large (~1 EiB) number of sectors with expired f05 deals an still datacap because DDO lets you extend a datacap allocation even after an f05 deal expires.

Using verified data is a better metric for the ratio as it counts non f05 data that is still active.