### PR TITLE
✨ Add hero stat cards for Key Metrics

### DIFF
--- a/web/src/components/StatCard.astro
+++ b/web/src/components/StatCard.astro
@@ -1,0 +1,80 @@
+---
+type LineChartFormat =
+  | "integer"
+  | "number"
+  | "pib"
+  | "tib"
+  | "fil"
+  | "mfil"
+  | "usdfc"
+  | "usd"
+  | "percent"
+
+type PercentMode = "fraction" | "points"
+
+interface Props {
+  id: string
+  title: string
+  x: string
+  y: string
+  format?: LineChartFormat
+  formatScale?: number
+  formatPrefix?: string
+  formatSuffix?: string
+  percentMode?: PercentMode
+}
+
+const {
+  id,
+  title,
+  x,
+  y,
+  format = "number",
+  formatScale,
+  formatPrefix,
+  formatSuffix,
+  percentMode = "fraction",
+} = Astro.props
+---
+
+<figure
+  class="stat-card"
+  data-stat-card
+  data-line-chart
+  data-chart-id={id}
+  data-x={x}
+  data-y={y}
+  data-format={format}
+  data-format-scale={formatScale}
+  data-format-prefix={formatPrefix}
+  data-format-suffix={formatSuffix}
+  data-percent-mode={percentMode}
+  data-show-moving-average="true"
+  data-moving-average-window-days="30"
+>
+  <figcaption class="stat-card__header">
+    <a href={`#${id}`} id={id} class="stat-card__label line-chart__title">{title}</a>
+    <span class="line-chart__headline" data-line-chart-last-value hidden></span>
+    <span class="line-chart__headline-tip" data-line-chart-headline-tip hidden></span>
+    <button
+      type="button"
+      class="line-chart__toggle"
+      data-line-chart-toggle
+      aria-expanded="false"
+      aria-label={`Expand ${title}`}
+      title={`Expand ${title}`}
+    >
+      +
+    </button>
+  </figcaption>
+
+  <span class="stat-card__value" data-stat-card-value></span>
+  <span class="stat-card__trend" data-stat-card-trend></span>
+  <svg class="stat-card__spark" aria-hidden="true"></svg>
+
+  <div class="line-chart__canvas">
+    <svg class="line-chart__svg" aria-hidden="true"></svg>
+    <p class="line-chart__empty" hidden>No data available for this range.</p>
+    <div class="line-chart__tooltip" hidden></div>
+  </div>
+</figure>

--- a/web/src/pages/numbers.astro
+++ b/web/src/pages/numbers.astro
@@ -2,6 +2,7 @@
 import type { ComponentProps } from "astro/types"
 import dailyMetricsDataset from "../data/generated/filecoin-daily-metrics.json"
 import LineChart from "../components/LineChart.astro"
+import StatCard from "../components/StatCard.astro"
 import Layout from "../layouts/Layout.astro"
 
 type LineChartProps = ComponentProps<typeof LineChart>
@@ -362,9 +363,25 @@ const serializedDailyMetrics = JSON.stringify(
       <section class="numbers-section" aria-labelledby={section.id}>
         <h2 id={section.id} class="numbers-section__legend">{section.title}</h2>
 
-        <div class="card-grid card-grid--two-up">
-          {
-            section.charts.map((chart) => (
+        {section.id === "key-metrics" ? (
+          <div class="stat-grid">
+            {section.charts.map((chart) => (
+              <StatCard
+                id={chart.id}
+                title={chart.title}
+                x={chartX}
+                y={chart.y}
+                format={chart.format}
+                formatScale={chart.formatScale}
+                formatPrefix={chart.formatPrefix}
+                formatSuffix={chart.formatSuffix}
+                percentMode={chart.percentMode}
+              />
+            ))}
+          </div>
+        ) : (
+          <div class="card-grid card-grid--two-up">
+            {section.charts.map((chart) => (
               <LineChart
                 id={chart.id}
                 title={chart.title}
@@ -378,9 +395,9 @@ const serializedDailyMetrics = JSON.stringify(
                 showMovingAverage={true}
                 movingAverageWindowDays={30}
               />
-            ))
-          }
-        </div>
+            ))}
+          </div>
+        )}
       </section>
     ))
   }
@@ -434,6 +451,7 @@ const serializedDailyMetrics = JSON.stringify(
 
     const DATASET_SELECTOR = "[data-numbers-dataset]"
     const CHART_SELECTOR = "[data-line-chart]"
+    const STAT_CARD_SELECTOR = "[data-stat-card]"
     const RANGE_BUTTON_SELECTOR = "[data-line-chart-range]"
     const EXPANDED_CHART_PARAM = "chart"
     const RANGE_PARAM = "range"
@@ -1155,7 +1173,109 @@ const serializedDailyMetrics = JSON.stringify(
         }
       }
 
-      const observers = charts.map((chart) => {
+      type ParsedStatCard = {
+        node: HTMLElement
+        data: LineChartPoint[]
+        format: LineChartFormat
+        formatScale: number
+        formatPrefix: string
+        formatSuffix: string
+        percentMode: PercentMode
+      }
+
+      const statCardNodes = Array.from(document.querySelectorAll<HTMLElement>(STAT_CARD_SELECTOR))
+      const statCards: ParsedStatCard[] = statCardNodes.map((node) => {
+        const x = node.dataset.x
+        const y = node.dataset.y
+        const chartId = node.dataset.chartId
+
+        if (!chartId || !x || !y) {
+          throw new Error("Stat card is missing required dataset attributes")
+        }
+
+        const xColumn = dataset[x]
+        const yColumn = dataset[y]
+
+        if (!xColumn || !yColumn) {
+          throw new Error(`Stat card ${chartId} references missing columns`)
+        }
+
+        const data: LineChartPoint[] = []
+
+        for (let i = 0; i < xColumn.length; i++) {
+          const rawX = xColumn[i]
+          const rawY = yColumn[i]
+          if (rawX == null || rawY == null) continue
+          const timestamp = toTimestamp(chartId, rawX)
+          const value = Number(rawY)
+          if (!Number.isFinite(value)) continue
+          data.push({ timestamp, value })
+        }
+
+        return {
+          node,
+          data,
+          format: parseFormat(node.dataset.format),
+          formatScale: parsePositiveNumber(node.dataset.formatScale, 1),
+          formatPrefix: node.dataset.formatPrefix ?? "",
+          formatSuffix: node.dataset.formatSuffix ?? "",
+          percentMode: parsePercentMode(node.dataset.percentMode),
+        }
+      })
+
+      function renderStatCard(card: ParsedStatCard): void {
+        const points = getPointsForRange(card.data, currentRange)
+        const valueEl = card.node.querySelector<HTMLElement>("[data-stat-card-value]")
+        const trendEl = card.node.querySelector<HTMLElement>("[data-stat-card-trend]")
+        const svg = card.node.querySelector<SVGElement>(".stat-card__spark")
+
+        if (!valueEl || !trendEl || !svg) return
+        if (points.length < 2) {
+          valueEl.textContent = "—"
+          trendEl.textContent = ""
+          svg.innerHTML = ""
+          return
+        }
+
+        const ma = buildMovingAverage(points.map((p) => p.value), 30)
+        const latest = ma[ma.length - 1]
+        const compareIndex = Math.max(0, ma.length - 1 - 30)
+        const prev = ma[compareIndex]
+
+        valueEl.textContent = formatValue(latest, card, "headline")
+
+        const pctChange = prev !== 0 ? ((latest - prev) / prev) * 100 : 0
+        const sign = pctChange > 0 ? "+" : ""
+        const trend = pctChange > 0 ? "▲" : pctChange < 0 ? "▼" : "■"
+        trendEl.textContent = `${trend} ${sign}${formatDecimal(pctChange, 2)}% 30d`
+
+        // Sparkline
+        const width = card.node.clientWidth
+        const height = 48
+        const pad = 2
+
+        const minX = points[0].timestamp
+        const maxX = points[points.length - 1].timestamp
+        const minY = Math.min(...ma)
+        let maxY = Math.max(...ma)
+        if (maxY === minY) maxY = minY + 1
+
+        const sx = (t: number) => pad + ((t - minX) / Math.max(maxX - minX, DAY_IN_MS)) * (width - pad * 2)
+        const sy = (v: number) => pad + ((maxY - v) / (maxY - minY)) * (height - pad * 2)
+
+        const d = ma.map((v, i) => `${i === 0 ? "M" : "L"} ${sx(points[i].timestamp)} ${sy(v)}`).join(" ")
+
+        svg.setAttribute("viewBox", `0 0 ${width} ${height}`)
+        svg.innerHTML = `<path d="${d}" fill="none" stroke="var(--color-border-strong)" stroke-width="1.5" />`
+      }
+
+      function renderAllStatCards(): void {
+        for (const card of statCards) {
+          renderStatCard(card)
+        }
+      }
+
+      const observers: ResizeObserver[] = charts.map((chart) => {
         const observer = new ResizeObserver(() => {
           renderChart(chart)
         })
@@ -1163,6 +1283,12 @@ const serializedDailyMetrics = JSON.stringify(
         observer.observe(chart.node)
         return observer
       })
+
+      for (const card of statCards) {
+        const observer = new ResizeObserver(() => renderStatCard(card))
+        observer.observe(card.node)
+        observers.push(observer)
+      }
 
       const rangeButtons = document.querySelectorAll<HTMLButtonElement>(RANGE_BUTTON_SELECTOR)
 
@@ -1182,6 +1308,7 @@ const serializedDailyMetrics = JSON.stringify(
           updateRangeButtons(currentRange)
           updateUrlState()
           renderAllCharts()
+          renderAllStatCards()
         })
       }
 
@@ -1207,6 +1334,7 @@ const serializedDailyMetrics = JSON.stringify(
       syncExpandedChartState()
       updateUrlState()
       renderAllCharts()
+      renderAllStatCards()
 
       if (expandedChartId) {
         requestAnimationFrame(() => {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -318,6 +318,11 @@
     padding: var(--space-4);
   }
 
+  .numbers-section:first-of-type {
+    border: 0;
+    padding: 0;
+  }
+
   .numbers-section + .numbers-section {
     margin-block-start: var(--space-5);
   }
@@ -354,6 +359,110 @@
   .chart-range-toggle button[aria-pressed="true"] {
     background: var(--color-text);
     color: var(--color-bg);
+  }
+
+  .stat-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: var(--space-4);
+  }
+
+  @media (min-width: 36rem) {
+    .stat-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 64rem) {
+    .stat-grid {
+      grid-template-columns: repeat(4, 1fr);
+    }
+  }
+
+  .stat-card {
+    margin: 0;
+    padding: var(--space-3) var(--space-4);
+    border: 1px solid var(--color-border);
+    display: grid;
+    gap: var(--space-1);
+  }
+
+  .stat-card__header {
+    position: relative;
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+  }
+
+  .stat-card__label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+  }
+
+  .stat-card__label a,
+  .stat-card .line-chart__title {
+    text-decoration: none;
+    color: inherit;
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  .stat-card .line-chart__toggle {
+    margin-inline-start: auto;
+  }
+
+  .stat-card .line-chart__headline,
+  .stat-card .line-chart__canvas {
+    display: none;
+  }
+
+  .stat-card__value {
+    font-size: clamp(1.5rem, 2.5vw, 2rem);
+    font-weight: 700;
+    line-height: 1.1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-card__trend {
+    font-size: 0.72rem;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-card__spark {
+    inline-size: 100%;
+    block-size: 48px;
+    margin-block-start: var(--space-1);
+  }
+
+  .stat-card.is-expanded {
+    --line-chart-height: 360px;
+    grid-column: 1 / -1;
+    padding: var(--space-4);
+    border-color: var(--color-border-strong);
+    background: var(--color-bg-muted);
+  }
+
+  .stat-card.is-expanded .stat-card__label {
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+
+  .stat-card.is-expanded .stat-card__value,
+  .stat-card.is-expanded .stat-card__trend,
+  .stat-card.is-expanded .stat-card__spark {
+    display: none;
+  }
+
+  .stat-card.is-expanded .line-chart__headline {
+    display: inline;
+    margin-inline-start: auto;
+  }
+
+  .stat-card.is-expanded .line-chart__canvas {
+    display: block;
   }
 
   .line-chart {


### PR DESCRIPTION
Replace line charts with big-number stat cards for the Key Metrics section. Each card shows the current value (large), 30-day trend percentage, and a compact sparkline.

Cards expand into full interactive charts via the existing expand system (+ button).

### Changes

- **`StatCard.astro`** — new component with dual `data-stat-card`/`data-line-chart` attributes so it participates in both rendering systems
- **`numbers.astro`** — key-metrics section renders `StatCard` instead of `LineChart`; added stat card parsing, rendering, and resize/range-change hooks
- **`styles.css`** — stat grid (responsive 1→2→4 cols), stat card styles, expanded state toggling (hides number/sparkline, shows full chart)