### PR TITLE
Declare dependency on model.daily_filecoin_pay_activity for filecoin_pay_operators_metrics

### DIFF
--- a/assets/main/daily/filecoin_pay_operators_metrics.sql
+++ b/assets/main/daily/filecoin_pay_operators_metrics.sql
@@ -2,6 +2,7 @@
 
 -- asset.depends = model.fevm_daily_checkpoints
 -- asset.depends = model.filecoin_pay_rail_rate_intervals
+-- asset.depends = model.daily_filecoin_pay_activity
 
 -- asset.column = date | UTC date.
 -- asset.column = operator | Filecoin Pay operator address.


### PR DESCRIPTION
### Motivation
- Ensure the `filecoin_pay_operators_metrics` asset declares its dependency on `model.daily_filecoin_pay_activity` so the build graph includes the daily activity data needed for accurate metrics.

### Description
- Added `-- asset.depends = model.daily_filecoin_pay_activity` to the header of `assets/main/daily/filecoin_pay_operators_metrics.sql`.

### Testing
- No automated tests were run for this metadata-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef9580e88c832eba1ac07b8a8defb8)