### PR TITLE
✨ Add network burn metrics

### DIFF
--- a/assets/main/daily/network_metrics.sql
+++ b/assets/main/daily/network_metrics.sql
@@ -23,6 +23,10 @@
 -- asset.column = gas_used_millions | Total gas used, in millions.
 -- asset.column = total_value_fil | FIL transferred by top-level messages.
 -- asset.column = total_gas_fee_fil | FIL paid in gas fees.
+-- asset.column = base_fee_burn_fil | FIL burned by message base fees.
+-- asset.column = base_fee_burn_usd | FIL burned by message base fees, valued with the daily average FIL price, in USD.
+-- asset.column = message_burn_fil | FIL burned by message execution.
+-- asset.column = message_burn_usd | FIL burned by message execution, valued with the daily average FIL price, in USD.
 -- asset.column = total_value_flow_fil | FIL value transferred plus gas fees.
 -- asset.column = protocol_revenue_fil | Daily total FIL burned on-chain, in FIL.
 -- asset.column = protocol_revenue_usd | Daily total FIL burned on-chain, valued with the daily average FIL price, in USD.
@@ -131,6 +135,12 @@ select
     coalesce(network_activity.gas_used_millions, 0) as gas_used_millions,
     coalesce(network_activity.total_value_fil, 0) as total_value_fil,
     coalesce(network_activity.total_gas_fee_fil, 0) as total_gas_fee_fil,
+    coalesce(network_activity.base_fee_burn_fil, 0) as base_fee_burn_fil,
+    coalesce(network_activity.base_fee_burn_fil, 0)
+        * market_data.fil_token_price_avg_usd as base_fee_burn_usd,
+    coalesce(network_activity.message_burn_fil, 0) as message_burn_fil,
+    coalesce(network_activity.message_burn_fil, 0)
+        * market_data.fil_token_price_avg_usd as message_burn_usd,
     coalesce(network_activity.total_value_flow_fil, 0) as total_value_flow_fil,
     coalesce(protocol_revenue.protocol_revenue_fil, 0) as protocol_revenue_fil,
     coalesce(protocol_revenue.protocol_revenue_fil, 0)

--- a/assets/model/daily/network_activity.sql
+++ b/assets/model/daily/network_activity.sql
@@ -7,6 +7,8 @@
 -- asset.column = transactions | Onchain transactions.
 -- asset.column = total_value_fil | FIL transferred by top-level messages.
 -- asset.column = total_gas_fee_fil | FIL paid in gas fees.
+-- asset.column = base_fee_burn_fil | FIL burned by message base fees.
+-- asset.column = message_burn_fil | FIL burned by message execution.
 -- asset.column = total_value_flow_fil | FIL value transferred plus gas fees.
 
 -- asset.not_null = date
@@ -14,6 +16,8 @@
 -- asset.not_null = transactions
 -- asset.not_null = total_value_fil
 -- asset.not_null = total_gas_fee_fil
+-- asset.not_null = base_fee_burn_fil
+-- asset.not_null = message_burn_fil
 -- asset.not_null = total_value_flow_fil
 -- asset.unique = date
 
@@ -23,6 +27,8 @@ select
     sum(transactions) as transactions,
     cast(sum(total_value_fil) as double) as total_value_fil,
     cast(sum(total_gas_fee_fil) as double) as total_gas_fee_fil,
+    cast(sum(base_fee_burn_fil) as double) as base_fee_burn_fil,
+    cast(sum(message_burn_fil) as double) as message_burn_fil,
     cast(sum(total_value_fil) + sum(total_gas_fee_fil) as double)
         as total_value_flow_fil
 from raw.daily_network_activity_by_method

--- a/assets/raw/daily/network_activity_by_method.sql
+++ b/assets/raw/daily/network_activity_by_method.sql
@@ -16,6 +16,16 @@ select
     sum(gas_used) / 1e6 as gas_used_millions,
     count(*) as transactions,
     cast(sum(cast(value as bignumeric) / 1e18) as float64) as total_value_fil,
+    cast(sum(cast(base_fee_burn as bignumeric) / 1e18) as float64)
+        as base_fee_burn_fil,
+    cast(
+        sum(
+            (
+                cast(base_fee_burn as bignumeric)
+                + cast(over_estimation_burn as bignumeric)
+            ) / 1e18
+        ) as float64
+    ) as message_burn_fil,
     cast(
         sum(
             (


### PR DESCRIPTION
Adds base fee burn and message-related burn metrics to daily network metrics.

- Rolls up base fee burn and message burn from Lily gas outputs
- Exposes FIL and USD columns in main.daily_network_metrics
- Checks: make check