### PR TITLE
🏷️ Add USDC.axl to Filecoin Pay ARR

### DIFF
--- a/assets/main/daily/filecoin_pay_operators_metrics.sql
+++ b/assets/main/daily/filecoin_pay_operators_metrics.sql
@@ -10,7 +10,7 @@
 -- asset.column = arr_eligible_rails | Active recurring rails counted toward ARR at end of day.
 -- asset.column = unique_payers | Payers across the operator's active rails at end of day.
 -- asset.column = unique_payees | Payees across the operator's active rails at end of day.
--- asset.column = arr_usdfc | End-of-day ARR run-rate from the operator's active ARR-eligible rails.
+-- asset.column = arr_filecoin_pay_usd | End-of-day USD ARR run-rate from the operator's active stablecoin recurring rails.
 
 -- asset.not_null = date
 -- asset.not_null = operator
@@ -19,7 +19,7 @@
 -- asset.not_null = arr_eligible_rails
 -- asset.not_null = unique_payers
 -- asset.not_null = unique_payees
--- asset.not_null = arr_usdfc
+-- asset.not_null = arr_filecoin_pay_usd
 
 with days as (
     select date, checkpoint_ordinal
@@ -53,7 +53,7 @@ select
     count(distinct payer) as unique_payers,
     count(distinct payee) as unique_payees,
     coalesce(sum(case when is_arr_eligible and rate_wei_per_epoch > 0 then rate_token_per_epoch else 0 end), 0)
-        * 2880 * 365 as arr_usdfc
+        * 2880 * 365 as arr_filecoin_pay_usd
 from operator_day_active_rails
 group by 1, 2
 order by date desc

--- a/assets/main/daily/network_metrics.sql
+++ b/assets/main/daily/network_metrics.sql
@@ -41,7 +41,7 @@
 -- asset.column = pledge_collateral_fil | End-of-day total pledge collateral locked by storage providers, in FIL.
 -- asset.column = filecoin_pay_active_payers | Payers with at least one active Filecoin Pay rail at end of day.
 -- asset.column = filecoin_pay_active_rails | Active Filecoin Pay rails at end of day.
--- asset.column = usdfc_paid | Gross USDFC paid through Filecoin Pay rails on the date.
+-- asset.column = filecoin_pay_paid_usd | Gross stablecoin paid through Filecoin Pay rails on the date, assuming tagged stablecoins at $1.
 -- asset.column = active_payers | Payers with at least one active chargeable warm storage dataset.
 -- asset.column = active_datasets | Active chargeable warm storage datasets.
 -- asset.column = new_payers | Payers whose first chargeable warm storage dataset started billing on the date.
@@ -182,7 +182,7 @@ select
         as pledge_collateral_fil,
     coalesce(pay_activity.active_payers, 0) as filecoin_pay_active_payers,
     coalesce(pay_activity.active_rails, 0) as filecoin_pay_active_rails,
-    coalesce(pay_activity.usdfc_paid, 0) as usdfc_paid,
+    coalesce(pay_activity.filecoin_pay_paid_usd, 0) as filecoin_pay_paid_usd,
     coalesce(warm_storage.active_payers, 0) as active_payers,
     coalesce(warm_storage.active_datasets, 0) as active_datasets,
     coalesce(warm_storage.new_payers, 0) as new_payers,

--- a/assets/main/daily/network_metrics.sql
+++ b/assets/main/daily/network_metrics.sql
@@ -46,7 +46,7 @@
 -- asset.column = active_datasets | Active chargeable warm storage datasets.
 -- asset.column = new_payers | Payers whose first chargeable warm storage dataset started billing on the date.
 -- asset.column = new_datasets | Warm storage datasets whose billing started on the date.
--- asset.column = arr_usdfc | End-of-day ARR run-rate from active ARR-eligible rails.
+-- asset.column = arr_filecoin_pay_usd | End-of-day USD ARR run-rate from active stablecoin recurring Filecoin Pay rails.
 -- asset.column = fil_token_price_avg_usd | Average FIL price in USD.
 -- asset.column = fil_token_volume_usd | FIL trading volume in USD.
 -- asset.column = fil_token_market_cap_usd | FIL market capitalization in USD.
@@ -187,7 +187,7 @@ select
     coalesce(warm_storage.active_datasets, 0) as active_datasets,
     coalesce(warm_storage.new_payers, 0) as new_payers,
     coalesce(warm_storage.new_datasets, 0) as new_datasets,
-    coalesce(pay_arr.arr_usdfc, 0) as arr_usdfc,
+    coalesce(pay_arr.arr_filecoin_pay_usd, 0) as arr_filecoin_pay_usd,
     market_data.fil_token_price_avg_usd,
     market_data.fil_token_volume_usd,
     market_data.fil_token_market_cap_usd,

--- a/assets/main/filecoin_pay/rails.sql
+++ b/assets/main/filecoin_pay/rails.sql
@@ -6,6 +6,9 @@
 -- asset.column = payer | Payer address.
 -- asset.column = payee | Payee address.
 -- asset.column = token | ERC20 token address.
+-- asset.column = token_symbol | ERC20 token symbol.
+-- asset.column = token_decimals | ERC20 token decimals.
+-- asset.column = is_stablecoin | Whether the rail token is a tagged stablecoin.
 -- asset.column = operator | Operator address.
 -- asset.column = service | Service classification.
 -- asset.column = validator | Validator address.
@@ -30,6 +33,9 @@ select
     payer,
     payee,
     token,
+    token_symbol,
+    token_decimals,
+    is_stablecoin,
     operator,
     service,
     validator,

--- a/assets/model/daily/filecoin_pay_activity.sql
+++ b/assets/model/daily/filecoin_pay_activity.sql
@@ -7,19 +7,15 @@
 -- asset.column = date | UTC date.
 -- asset.column = active_payers | Payers with at least one active rail at end of day.
 -- asset.column = active_rails | Active rails at end of day.
--- asset.column = usdfc_paid | Gross USDFC paid through Filecoin Pay rails on the date.
+-- asset.column = filecoin_pay_paid_usd | Gross stablecoin paid through Filecoin Pay rails on the date, assuming tagged stablecoins at $1.
 
 -- asset.not_null = date
 -- asset.not_null = active_payers
 -- asset.not_null = active_rails
--- asset.not_null = usdfc_paid
+-- asset.not_null = filecoin_pay_paid_usd
 -- asset.unique = date
 
-with params as (
-    select
-        '0x80b98d3aa09ffff255c3ba4a241111ff1262f045' as usdfc_token,
-        cast(1000000000000000000 as decimal(38, 0)) as token_scale
-), days as (
+with days as (
     select date, checkpoint_ordinal
     from model.fevm_daily_checkpoints
     where date >= coalesce(
@@ -38,7 +34,7 @@ with params as (
     from model.filecoin_pay_rails
 ), payment_events as (
     select
-        date(to_timestamp(events.block_number * 30 + 1598306400)) as date,
+        events.file_date as date,
         case
             when events.event_name = 'RailSettled' then
                 cast(json_extract_string(events.args, '$.totalSettledAmount') as decimal(38, 0))
@@ -46,29 +42,37 @@ with params as (
                 cast(json_extract_string(events.args, '$.netPayeeAmount') as decimal(38, 0))
                 + cast(json_extract_string(events.args, '$.operatorCommission') as decimal(38, 0))
                 + cast(json_extract_string(events.args, '$.networkFee') as decimal(38, 0))
-        end as paid_wei
+        end / power(cast(10 as decimal(38, 0)), payment_rails.token_decimals)
+            as paid_usd
     from raw.fevm_eth_logs_decoded as events
     join model.filecoin_pay_rails as payment_rails
         on cast(json_extract_string(events.args, '$.railId') as bigint) = payment_rails.rail_id
     where events.abi_name = 'filecoin_pay_v1'
       and events.event_name in ('RailSettled', 'RailOneTimePaymentProcessed')
-      and payment_rails.token = (select usdfc_token from params)
+      and payment_rails.is_stablecoin
+      and events.file_date <= current_date - 1
 ), daily_payments as (
     select
         date,
-        sum(paid_wei) / (select token_scale from params) as usdfc_paid
+        sum(paid_usd) as filecoin_pay_paid_usd
     from payment_events
+    group by 1
+), active_counts as (
+    select
+        days.date,
+        count(distinct rails.payer) as active_payers,
+        count(distinct rails.rail_id) as active_rails
+    from days
+    left join rails
+        on rails.created_ordinal <= days.checkpoint_ordinal
+       and coalesce(rails.terminated_ordinal, 9223372036854775807) > days.checkpoint_ordinal
     group by 1
 )
 select
-    days.date,
-    count(distinct rails.payer) as active_payers,
-    count(distinct rails.rail_id) as active_rails,
-    coalesce(daily_payments.usdfc_paid, 0) as usdfc_paid
-from days
-left join rails
-    on rails.created_ordinal <= days.checkpoint_ordinal
-   and coalesce(rails.terminated_ordinal, 9223372036854775807) > days.checkpoint_ordinal
+    active_counts.date,
+    active_counts.active_payers,
+    active_counts.active_rails,
+    coalesce(daily_payments.filecoin_pay_paid_usd, 0) as filecoin_pay_paid_usd
+from active_counts
 left join daily_payments using (date)
-group by 1, 4
 order by date desc

--- a/assets/model/daily/filecoin_pay_arr.sql
+++ b/assets/model/daily/filecoin_pay_arr.sql
@@ -4,10 +4,10 @@
 -- asset.depends = model.filecoin_pay_rail_rate_intervals
 
 -- asset.column = date | UTC date.
--- asset.column = arr_usdfc | End-of-day ARR run-rate from active ARR-eligible rails.
+-- asset.column = arr_filecoin_pay_usd | End-of-day USD ARR run-rate from active stablecoin recurring rails.
 
 -- asset.not_null = date
--- asset.not_null = arr_usdfc
+-- asset.not_null = arr_filecoin_pay_usd
 -- asset.unique = date
 
 with days as (
@@ -20,7 +20,7 @@ with days as (
 )
 select
     days.date,
-    coalesce(sum(intervals.rate_token_per_epoch), 0) * 2880 * 365 as arr_usdfc
+    coalesce(sum(intervals.rate_token_per_epoch), 0) * 2880 * 365 as arr_filecoin_pay_usd
 from days
 left join model.filecoin_pay_rail_rate_intervals as intervals
     on intervals.is_arr_eligible

--- a/assets/model/fevm_daily_checkpoints.sql
+++ b/assets/model/fevm_daily_checkpoints.sql
@@ -1,6 +1,7 @@
 -- asset.description = Daily FEVM end-of-day checkpoints.
 
 -- asset.depends = raw.fevm_eth_logs_decoded
+-- asset.depends = raw.fevm_eth_logs
 
 -- asset.column = date | UTC date.
 -- asset.column = checkpoint_ordinal | Last FEVM event ordinal observed on or before the date.
@@ -11,18 +12,17 @@
 
 with chain_day_ordinals as (
     select
-        date(to_timestamp(block_number * 30 + 1598306400)) as date,
+        file_date as date,
         max(block_number * 1000000 + log_index) as day_end_ordinal
     from raw.fevm_eth_logs_decoded
+    where file_date <= current_date - 1
     group by 1
 ),
 days as (
-    select cast(generate_series as date) as date
-    from generate_series(
-        (select min(date) from chain_day_ordinals),
-        (select max(date) from chain_day_ordinals),
-        interval 1 day
-    )
+    select distinct file_date as date
+    from raw.fevm_eth_logs
+    where file_date between (select min(date) from chain_day_ordinals)
+        and current_date - 1
 )
 select
     days.date,

--- a/assets/model/filecoin_pay/rail_rate_intervals.sql
+++ b/assets/model/filecoin_pay/rail_rate_intervals.sql
@@ -8,6 +8,9 @@
 -- asset.column = payer | Payer address.
 -- asset.column = payee | Payee address.
 -- asset.column = token | ERC20 token address.
+-- asset.column = token_symbol | ERC20 token symbol.
+-- asset.column = token_decimals | ERC20 token decimals.
+-- asset.column = is_stablecoin | Whether the rail token is a tagged stablecoin.
 -- asset.column = operator | Operator address.
 -- asset.column = validator | Validator address.
 -- asset.column = is_arr_eligible | Whether the rail counts toward ARR.
@@ -59,6 +62,9 @@ valid_change_points as (
         rails.payer,
         rails.payee,
         rails.token,
+        rails.token_symbol,
+        rails.token_decimals,
+        rails.is_stablecoin,
         rails.operator,
         rails.validator,
         rails.is_arr_eligible,
@@ -78,6 +84,9 @@ ordered_intervals as (
         payer,
         payee,
         token,
+        token_symbol,
+        token_decimals,
+        is_stablecoin,
         operator,
         validator,
         is_arr_eligible,
@@ -96,6 +105,9 @@ intervals as (
         payer,
         payee,
         token,
+        token_symbol,
+        token_decimals,
+        is_stablecoin,
         operator,
         validator,
         is_arr_eligible,
@@ -118,6 +130,9 @@ select
     payer,
     payee,
     token,
+    token_symbol,
+    token_decimals,
+    is_stablecoin,
     operator,
     validator,
     is_arr_eligible,
@@ -139,6 +154,7 @@ select
         else to_timestamp(cast(end_ordinal / 1000000 as bigint) * 30 + (select genesis_timestamp from params))
     end as end_at,
     rate_wei_per_epoch,
-    cast(rate_wei_per_epoch as decimal(38, 0)) / cast(1000000000000000000 as decimal(38, 0)) as rate_token_per_epoch
+    cast(rate_wei_per_epoch as decimal(38, 0))
+        / power(cast(10 as decimal(38, 0)), token_decimals) as rate_token_per_epoch
 from intervals
 order by start_at desc

--- a/assets/model/filecoin_pay/rails.sql
+++ b/assets/model/filecoin_pay/rails.sql
@@ -6,6 +6,9 @@
 -- asset.column = payer | Payer address.
 -- asset.column = payee | Payee address.
 -- asset.column = token | ERC20 token address.
+-- asset.column = token_symbol | ERC20 token symbol.
+-- asset.column = token_decimals | ERC20 token decimals.
+-- asset.column = is_stablecoin | Whether the rail token is a tagged stablecoin.
 -- asset.column = operator | Operator address.
 -- asset.column = service | Service classification.
 -- asset.column = validator | Validator address.
@@ -31,9 +34,21 @@
 with params as (
     select
         1598306400 as genesis_timestamp,
-        '0x80b98d3aa09ffff255c3ba4a241111ff1262f045' as usdfc_token,
         '0xa5f90bc2aa73a2e0bad4d7092a932644d5dd5d71' as dealbot_payer,
         '0x56e53c5e7f27504b810494cc3b88b2aa0645a839' as storacha_operator
+),
+tokens as (
+    select
+        '0x80b98d3aa09ffff255c3ba4a241111ff1262f045' as token,
+        'USDFC' as token_symbol,
+        18 as token_decimals,
+        true as is_stablecoin
+    union all
+    select
+        '0xeb466342c4d449bc9f53a865d5cb90586f405215' as token,
+        'USDC.axl' as token_symbol,
+        6 as token_decimals,
+        true as is_stablecoin
 ),
 rail_created as (
     select
@@ -80,6 +95,9 @@ select
     created.payer,
     created.payee,
     created.token,
+    tokens.token_symbol,
+    tokens.token_decimals,
+    coalesce(tokens.is_stablecoin, false) as is_stablecoin,
     created.operator,
     case
         when created.operator = (select storacha_operator from params) then 'Storacha'
@@ -88,7 +106,7 @@ select
     created.validator,
     created.service_fee_recipient,
     created.commission_rate_bps,
-    created.token = (select usdfc_token from params)
+    coalesce(tokens.is_stablecoin, false)
         and created.payer != (select dealbot_payer from params) as is_arr_eligible,
     created.created_block,
     created.created_log_index,
@@ -103,6 +121,8 @@ select
     terminated.terminated_end_at,
     terminated.terminated_block is not null as is_terminated
 from rail_created as created
+left join tokens
+    on created.token = tokens.token
 left join rail_terminated as terminated
     on created.rail_id = terminated.rail_id
    and terminated.row_num = 1

--- a/assets/model/storage_provider/current_info.py
+++ b/assets/model/storage_provider/current_info.py
@@ -49,8 +49,10 @@ from multiaddr import Multiaddr
 import fdp
 
 RPC_URL = "https://filecoin.chain.love/rpc"
-BATCH_SIZE = 20
-MAX_CONCURRENT = 2
+BATCH_SIZE = 10
+MAX_CONCURRENT = 1
+MAX_RPC_ATTEMPTS = 5
+BASE_RETRY_SECONDS = 5
 ATTO_FIL = Decimal("1000000000000000000")
 RPC_METHODS = {
     "info": "Filecoin.StateMinerInfo",
@@ -203,9 +205,28 @@ def build_row(
 
 
 async def post_rpc(client: httpx.AsyncClient, payload: Any) -> Any:
-    response = await client.post(RPC_URL, json=payload)
-    response.raise_for_status()
-    return response.json()
+    for attempt in range(1, MAX_RPC_ATTEMPTS + 1):
+        response = await client.post(RPC_URL, json=payload)
+        if response.status_code != 429:
+            response.raise_for_status()
+            return response.json()
+
+        if attempt == MAX_RPC_ATTEMPTS:
+            response.raise_for_status()
+
+        await asyncio.sleep(retry_delay(response, attempt))
+
+    raise RuntimeError("JSON-RPC request failed without a response")
+
+
+def retry_delay(response: httpx.Response, attempt: int) -> float:
+    retry_after = response.headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return BASE_RETRY_SECONDS * attempt
 
 
 def atto_to_fil(value: Any) -> float | None:

--- a/assets/raw/fevm/eth_logs.py
+++ b/assets/raw/fevm/eth_logs.py
@@ -47,8 +47,8 @@ def eth_logs() -> None:
     last = last_loaded_date()
     from_day = last + dt.timedelta(days=1) if last else START_DATE
 
-    today = dt.date.today()
-    if from_day > today:
+    latest_day = dt.datetime.now(dt.UTC).date() - dt.timedelta(days=1)
+    if from_day > latest_day:
         return
 
     with fdp.db_connection() as conn:
@@ -58,7 +58,7 @@ def eth_logs() -> None:
 
         with httpx.Client(follow_redirects=True, timeout=10) as client:
             day = from_day
-            while day <= today:
+            while day <= latest_day:
                 url = build_url(day)
                 resp = client.head(url)
                 if resp.status_code == 404:

--- a/web/scripts/datasets/filecoin-daily-metrics.ts
+++ b/web/scripts/datasets/filecoin-daily-metrics.ts
@@ -26,7 +26,7 @@ const SQL = `
     reward_per_wincount_fil,
     coalesce(filecoin_pay_active_payers, 0) AS filecoin_pay_active_payers,
     coalesce(filecoin_pay_active_rails, 0) AS filecoin_pay_active_rails,
-    coalesce(usdfc_paid, 0) AS usdfc_paid,
+    coalesce(filecoin_pay_paid_usd, 0) AS filecoin_pay_paid_usd,
     coalesce(arr_filecoin_pay_usd, 0) AS arr_filecoin_pay_usd,
     revenue_coverage_ratio,
     0 AS high_profile_paying_clients,

--- a/web/scripts/datasets/filecoin-daily-metrics.ts
+++ b/web/scripts/datasets/filecoin-daily-metrics.ts
@@ -1,6 +1,7 @@
 import { DuckDBInstance } from "@duckdb/node-api";
 
 const DAILY_NETWORK_METRICS_PARQUET_URL =
+  process.env.DAILY_NETWORK_METRICS_PARQUET_URL ??
   "https://data.filecoindataportal.xyz/daily_network_metrics.parquet";
 
 type DatasetValue = boolean | number | string | null;
@@ -26,7 +27,7 @@ const SQL = `
     coalesce(filecoin_pay_active_payers, 0) AS filecoin_pay_active_payers,
     coalesce(filecoin_pay_active_rails, 0) AS filecoin_pay_active_rails,
     coalesce(usdfc_paid, 0) AS usdfc_paid,
-    coalesce(arr_usdfc, 0) AS arr_usdfc,
+    coalesce(arr_filecoin_pay_usd, 0) AS arr_filecoin_pay_usd,
     revenue_coverage_ratio,
     0 AS high_profile_paying_clients,
     fil_token_price_avg_usd,

--- a/web/src/components/LineChart.astro
+++ b/web/src/components/LineChart.astro
@@ -6,7 +6,6 @@ type LineChartFormat =
   | "tib"
   | "fil"
   | "mfil"
-  | "usdfc"
   | "usd"
   | "percent"
 

--- a/web/src/components/StatCard.astro
+++ b/web/src/components/StatCard.astro
@@ -6,7 +6,6 @@ type LineChartFormat =
   | "tib"
   | "fil"
   | "mfil"
-  | "usdfc"
   | "usd"
   | "percent"
 

--- a/web/src/pages/numbers.astro
+++ b/web/src/pages/numbers.astro
@@ -128,11 +128,11 @@ const sections = [
         format: "integer",
       },
       {
-        id: "foc-usdfc-paid",
-        title: "USDFC Paid",
-        description: "Gross USDFC paid through Filecoin Pay rails per day.",
-        y: "usdfc_paid",
-        format: "usdfc",
+        id: "foc-filecoin-pay-paid-usd",
+        title: "Filecoin Pay Paid",
+        description: "Gross stablecoin paid through Filecoin Pay rails per day, including USDFC and USDC.axl.",
+        y: "filecoin_pay_paid_usd",
+        format: "usd",
       },
       {
         id: "foc-arr-filecoin-pay-usd",
@@ -407,7 +407,6 @@ const serializedDailyMetrics = JSON.stringify(
       | "tib"
       | "fil"
       | "mfil"
-      | "usdfc"
       | "usd"
       | "percent"
 
@@ -577,7 +576,6 @@ const serializedDailyMetrics = JSON.stringify(
           case "tib":
           case "fil":
           case "mfil":
-          case "usdfc":
           case "usd":
           case "percent":
             return value
@@ -689,7 +687,6 @@ const serializedDailyMetrics = JSON.stringify(
           pib: " PiB",
           tib: " TiB",
           fil: " FIL",
-          usdfc: " USDFC",
         } satisfies Record<Exclude<LineChartFormat, "integer" | "mfil" | "usd" | "percent">, string>
 
         return `${chart.formatPrefix}${formatDecimal(scaledValue, maximumFractionDigits)}${suffixByFormat[chart.format]}${chart.formatSuffix}`

--- a/web/src/pages/numbers.astro
+++ b/web/src/pages/numbers.astro
@@ -61,11 +61,11 @@ const sections = [
     columns: 3,
     charts: [
       {
-        id: "total-arr-usdfc",
-        title: "USDFC ARR Run-Rate",
-        description: "Annualized value of active recurring Filecoin Pay rails at each UTC day-end.",
-        y: "arr_usdfc",
-        format: "usdfc",
+        id: "total-arr-filecoin-pay-usd",
+        title: "Filecoin Pay ARR Run-Rate",
+        description: "Annualized USD value of active recurring Filecoin Pay stablecoin rails, including USDFC and USDC.axl, at each UTC day-end.",
+        y: "arr_filecoin_pay_usd",
+        format: "usd",
       },
       {
         id: "revenue-coverage-ratio",
@@ -135,11 +135,11 @@ const sections = [
         format: "usdfc",
       },
       {
-        id: "foc-arr-usdfc",
-        title: "USDFC ARR Run-Rate",
-        description: "Annualized value of active recurring Filecoin Pay rails at each UTC day-end.",
-        y: "arr_usdfc",
-        format: "usdfc",
+        id: "foc-arr-filecoin-pay-usd",
+        title: "Filecoin Pay ARR Run-Rate",
+        description: "Annualized USD value of active recurring Filecoin Pay stablecoin rails, including USDFC and USDC.axl, at each UTC day-end.",
+        y: "arr_filecoin_pay_usd",
+        format: "usd",
       },
     ],
   },


### PR DESCRIPTION
Adds tagged Filecoin Pay stablecoin metadata for USDFC and USDC.axl, applies token-decimal scaling, and renames ARR outputs to `arr_filecoin_pay_usd`.

Updates settled Filecoin Pay volume from `usdfc_paid` to `filecoin_pay_paid_usd`, counting only settlement/payment events from blessed stablecoin rails (`RailSettled` and `RailOneTimePaymentProcessed`). Deposits, lockups, and collateral are not counted as revenue/payment volume.

Updates network metrics and Numbers page copy to describe ARR as active recurring stablecoin rail run-rate and paid volume as realized gross stablecoin payments.