### PR TITLE
✨ Add keep existing on failure metadata

### DIFF
--- a/assets/model/storage_provider/current_info.py
+++ b/assets/model/storage_provider/current_info.py
@@ -6,6 +6,7 @@
 # asset.depends = model.verified_claims
 
 # asset.materialization = dataframe
+# asset.keep_existing_on_failure = true
 
 # asset.column = provider_id | Filecoin storage provider actor id address.
 # asset.column = owner_id | Current owner actor id address.

--- a/docs/fdp/assets.md
+++ b/docs/fdp/assets.md
@@ -12,6 +12,7 @@
 - Optional and repeatable `asset.depends`
 - Required on Python assets: `asset.materialization` (`dataframe` or `custom`)
 - Optional on SQL assets: `asset.resource` (currently `bigquery.lily`)
+- Optional: `asset.keep_existing_on_failure = true` to continue with the existing table when refresh fails
 - Optional and repeatable `asset.column` as `column_name | description`
 - Optional and repeatable `asset.not_null`
 - Optional and repeatable `asset.unique`
@@ -22,6 +23,7 @@
 - `main.*` assets must fully document columns with `asset.column`
 - If `asset.column` is present, documented columns must exactly match the materialized columns by name
 - Inline tests (`asset.not_null`, `asset.unique`, `asset.assert`) are declared in the asset header and run against the materialized table
+- `asset.keep_existing_on_failure = true` requires the table to already exist; first materialization still fails if refresh fails
 - Leave a blank line between the different metadata sections (`description`, `materialization`, tests, ...)
 - Custom SQL tests live under `assets/` as `*.test.sql` files and are attached to assets by path
 - `uv run fdp materialize schema.table` refreshes only the selected assets by default

--- a/fdp/assets.py
+++ b/fdp/assets.py
@@ -22,6 +22,7 @@ SUPPORTED_METADATA_KEYS = {
     "column",
     "materialization",
     "resource",
+    "keep_existing_on_failure",
 }
 VALID_SQL_RESOURCES = {"bigquery.lily"}
 IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -77,6 +78,7 @@ class Asset:
     kind: AssetKind
     python_materialization: PythonMaterialization | None
     resource: str | None
+    keep_existing_on_failure: bool
     depends: tuple[str, ...]
     description: str | None
     columns: tuple[AssetColumn, ...]
@@ -268,6 +270,11 @@ def asset_from_path(path: Path, assets_root: Path) -> Asset:
     schema, name = asset_identity_from_path(path, assets_root)
     python_materialization = parse_python_materialization(kind, metadata, path)
     resource = parse_asset_resource(kind, metadata, path)
+    keep_existing_on_failure = parse_bool_metadata(
+        metadata,
+        "keep_existing_on_failure",
+        path,
+    )
 
     return Asset(
         name=name,
@@ -277,6 +284,7 @@ def asset_from_path(path: Path, assets_root: Path) -> Asset:
         kind=kind,
         python_materialization=python_materialization,
         resource=resource,
+        keep_existing_on_failure=keep_existing_on_failure,
         depends=tuple(parse_dependencies(metadata.get("depends", []), path)),
         description=optional_metadata_value(metadata, "description", path),
         columns=tuple(parse_columns(metadata.get("column", []), path)),
@@ -558,6 +566,25 @@ def parse_asset_resource(
             f"Expected one of: {known_resources}."
         )
     return resource
+
+
+def parse_bool_metadata(
+    metadata: dict[str, list[str]],
+    key: str,
+    path: Path,
+) -> bool:
+    values = metadata.get(key, [])
+    if not values:
+        return False
+    if len(values) != 1:
+        raise ValueError(f"asset.{key} must appear once in {path}")
+
+    value = values[0].strip().lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ValueError(f"asset.{key} must be true or false in {path}")
 
 
 def python_asset_function_name(path: Path) -> str:

--- a/fdp/materialize.py
+++ b/fdp/materialize.py
@@ -8,6 +8,7 @@ import polars as pl
 
 from fdp.api import (
     db_connection,
+    default_db_path,
     quote_identifier,
     quote_table_key,
     replace_table_arrow,
@@ -69,12 +70,31 @@ def materialize_assets(assets: list[Asset]) -> None:
     total = len(assets)
     count_width = len(str(total))
     asset_width = max((len(asset.key) for asset in assets), default=0)
+    kept_existing: list[str] = []
 
     for index, asset in enumerate(assets, start=1):
         started_at = perf_counter()
         try:
             materialize_asset(asset)
-        except Exception:
+        except Exception as exc:
+            elapsed_seconds = perf_counter() - started_at
+            if can_keep_existing(asset):
+                kept_existing.append(asset.key)
+                print(
+                    format_materialize_status(
+                        index,
+                        total,
+                        count_width,
+                        asset_width,
+                        asset,
+                        "KEEP_EXISTING",
+                        elapsed_seconds,
+                    ),
+                    flush=True,
+                )
+                print(f"  {type(exc).__name__}: {exc}", flush=True)
+                continue
+
             print(
                 format_materialize_status(
                     index,
@@ -83,7 +103,7 @@ def materialize_assets(assets: list[Asset]) -> None:
                     asset_width,
                     asset,
                     "FAIL",
-                    perf_counter() - started_at,
+                    elapsed_seconds,
                 ),
                 flush=True,
             )
@@ -100,6 +120,20 @@ def materialize_assets(assets: list[Asset]) -> None:
             ),
             flush=True,
         )
+
+    if kept_existing:
+        print("Kept existing tables after refresh failures:", flush=True)
+        for key in kept_existing:
+            print(f"  - {key}", flush=True)
+
+
+def can_keep_existing(asset: Asset) -> bool:
+    if not asset.keep_existing_on_failure:
+        return False
+    if not default_db_path().exists():
+        return False
+    with db_connection(read_only=True) as conn:
+        return table_exists(conn, asset.schema, asset.name)
 
 
 def format_materialize_status(


### PR DESCRIPTION
Adds `asset.keep_existing_on_failure = true` for assets that can continue with their existing materialized table when refresh fails.

- Parses the new boolean asset metadata
- Continues materialization when the table already exists
- Marks `model.storage_provider_current_info` as tolerant
- Documents the metadata option

Verified with `make check`.