### PR TITLE
✨ Clean network burn metrics

### DIFF
--- a/assets/main/daily/network_metrics.sql
+++ b/assets/main/daily/network_metrics.sql
@@ -11,7 +11,7 @@
 -- asset.depends = raw.coincodex_filecoin_market_data
 -- asset.depends = raw.daily_network_power
 -- asset.depends = raw.daily_network_economics
--- asset.depends = raw.daily_protocol_revenue
+-- asset.depends = model.daily_network_burn
 -- asset.depends = raw.daily_pgf_deployments
 
 -- asset.column = date | UTC date.
@@ -30,14 +30,16 @@
 -- asset.column = base_fee_burn_usd | FIL burned by message base fees, valued with the daily average FIL price, in USD.
 -- asset.column = message_burn_fil | FIL burned by message execution.
 -- asset.column = message_burn_usd | FIL burned by message execution, valued with the daily average FIL price, in USD.
+-- asset.column = message_miner_penalty_burn_fil | FIL burned by message execution miner penalties.
+-- asset.column = message_miner_penalty_burn_usd | FIL burned by message execution miner penalties, valued with the daily average FIL price, in USD.
 -- asset.column = total_value_flow_fil | FIL value transferred plus gas fees.
--- asset.column = protocol_revenue_fil | Daily total FIL burned on-chain, in FIL.
--- asset.column = protocol_revenue_usd | Daily total FIL burned on-chain, valued with the daily average FIL price, in USD.
+-- asset.column = protocol_revenue_fil | Total FIL burned.
+-- asset.column = protocol_revenue_usd | Total FIL burned, valued at average FIL/USD price.
 -- asset.column = circulating_fil | End-of-day VM circulating supply, in FIL.
 -- asset.column = mined_fil | End-of-day cumulative mined FIL, in FIL.
 -- asset.column = vested_fil | End-of-day cumulative vested FIL, in FIL.
 -- asset.column = locked_fil | End-of-day VM locked FIL, in FIL.
--- asset.column = burnt_fil | End-of-day cumulative burnt FIL, in FIL.
+-- asset.column = burnt_fil | End-of-day cumulative burned FIL, in FIL.
 -- asset.column = pledge_collateral_fil | End-of-day total pledge collateral locked by storage providers, in FIL.
 -- asset.column = filecoin_pay_active_payers | Payers with at least one active Filecoin Pay rail at end of day.
 -- asset.column = filecoin_pay_active_rails | Active Filecoin Pay rails at end of day.
@@ -66,9 +68,9 @@
 -- asset.column = block_rewards_usd_per_qap_tib_day | Exact block rewards minted on the date per 1 TiB of network quality adjusted power, in USD.
 -- asset.column = reward_per_wincount_fil | Exact reward allocated per win count on the date, in FIL.
 -- asset.column = annual_pgf_deployments_usd | Public goods funding deployments disbursed over the trailing 365 days, in USD.
--- asset.column = annual_protocol_revenue_usd | Protocol revenue over the trailing 365 days, in USD.
+-- asset.column = annual_protocol_revenue_usd | Total FIL burned over the trailing 365 days, valued at average FIL/USD price.
 -- asset.column = annual_block_rewards_usd | Block reward issuance over the trailing 365 days, in USD.
--- asset.column = revenue_coverage_ratio | Annual protocol revenue divided by annual public goods funding and block reward issuance.
+-- asset.column = revenue_coverage_ratio | Trailing-365-day protocol revenue divided by annual public goods funding and block reward issuance.
 
 -- asset.not_null = date
 -- asset.unique = date
@@ -121,7 +123,7 @@ with verified_claims as (
     union
     select date from market_data
     union
-    select date from raw.daily_protocol_revenue
+    select date from model.daily_network_burn
     union
     select date from raw.daily_network_economics
     union
@@ -172,9 +174,14 @@ select
     coalesce(network_activity.message_burn_fil, 0) as message_burn_fil,
     coalesce(network_activity.message_burn_fil, 0)
         * market_data.fil_token_price_avg_usd as message_burn_usd,
+    coalesce(network_burn.message_miner_penalty_burn_fil, 0)
+        as message_miner_penalty_burn_fil,
+    coalesce(network_burn.message_miner_penalty_burn_fil, 0)
+        * market_data.fil_token_price_avg_usd
+        as message_miner_penalty_burn_usd,
     coalesce(network_activity.total_value_flow_fil, 0) as total_value_flow_fil,
-    coalesce(protocol_revenue.protocol_revenue_fil, 0) as protocol_revenue_fil,
-    coalesce(protocol_revenue.protocol_revenue_fil, 0)
+    coalesce(network_burn.total_burn_fil, 0) as protocol_revenue_fil,
+    coalesce(network_burn.total_burn_fil, 0)
         * market_data.fil_token_price_avg_usd as protocol_revenue_usd,
     coalesce(network_economics.circulating_fil, 0) as circulating_fil,
     coalesce(network_economics.mined_fil, 0) as mined_fil,
@@ -227,7 +234,7 @@ left join pgf_deployments_by_date as pgf_deployments
     using (date)
 left join market_data
     using (date)
-left join raw.daily_protocol_revenue as protocol_revenue
+left join model.daily_network_burn as network_burn
     using (date)
 left join raw.daily_network_economics as network_economics
     using (date)
@@ -245,7 +252,7 @@ left join model.daily_network_activity as network_activity
     using (date)
 ), annual_metrics as (
     select
-        daily_metrics.*,
+        *,
         (circulating_fil - lag(circulating_fil, 365) over (order by date))
             / nullif(lag(circulating_fil, 365) over (order by date), 0)
             as yearly_inflation_rate,

--- a/assets/model/daily/network_activity.sql
+++ b/assets/model/daily/network_activity.sql
@@ -9,6 +9,7 @@
 -- asset.column = total_gas_fee_fil | FIL paid in gas fees.
 -- asset.column = base_fee_burn_fil | FIL burned by message base fees.
 -- asset.column = message_burn_fil | FIL burned by message execution.
+-- asset.column = message_miner_penalty_burn_fil | FIL burned by miner penalties from message execution.
 -- asset.column = total_value_flow_fil | FIL value transferred plus gas fees.
 
 -- asset.not_null = date
@@ -18,6 +19,7 @@
 -- asset.not_null = total_gas_fee_fil
 -- asset.not_null = base_fee_burn_fil
 -- asset.not_null = message_burn_fil
+-- asset.not_null = message_miner_penalty_burn_fil
 -- asset.not_null = total_value_flow_fil
 -- asset.unique = date
 
@@ -29,6 +31,8 @@ select
     cast(sum(total_gas_fee_fil) as double) as total_gas_fee_fil,
     cast(sum(base_fee_burn_fil) as double) as base_fee_burn_fil,
     cast(sum(message_burn_fil) as double) as message_burn_fil,
+    cast(sum(message_miner_penalty_burn_fil) as double)
+        as message_miner_penalty_burn_fil,
     cast(sum(total_value_fil) + sum(total_gas_fee_fil) as double)
         as total_value_flow_fil
 from raw.daily_network_activity_by_method

--- a/assets/model/daily/network_burn.sql
+++ b/assets/model/daily/network_burn.sql
@@ -1,0 +1,47 @@
+-- asset.description = Daily network burn components.
+
+-- asset.depends = raw.daily_network_burn
+-- asset.depends = raw.daily_miner_cron_fees
+-- asset.depends = model.daily_network_activity
+
+-- asset.column = date | UTC date.
+-- asset.column = total_burn_fil | Total FIL burned on-chain.
+-- asset.column = message_gas_burn_fil | FIL burned by message base fees and over-estimation.
+-- asset.column = message_miner_penalty_burn_fil | FIL burned by message execution miner penalties.
+-- asset.column = miner_cron_burn_fil | FIL burned during miner cron events.
+-- asset.column = miner_cron_fee_assessed_fil | FIL fees assessed during miner cron events.
+-- asset.column = miner_cron_penalty_assessed_fil | FIL penalties assessed during miner cron events.
+-- asset.column = unattributed_burn_fil | FIL burned by other mechanisms.
+
+-- asset.not_null = date
+-- asset.not_null = total_burn_fil
+-- asset.not_null = message_gas_burn_fil
+-- asset.not_null = message_miner_penalty_burn_fil
+-- asset.not_null = miner_cron_burn_fil
+-- asset.not_null = miner_cron_fee_assessed_fil
+-- asset.not_null = miner_cron_penalty_assessed_fil
+-- asset.not_null = unattributed_burn_fil
+-- asset.unique = date
+
+select
+    network_burn.date,
+    network_burn.total_burn_fil,
+    coalesce(network_activity.message_burn_fil, 0) as message_gas_burn_fil,
+    coalesce(network_activity.message_miner_penalty_burn_fil, 0)
+        as message_miner_penalty_burn_fil,
+    coalesce(miner_cron_fees.miner_cron_burn_fil, 0) as miner_cron_burn_fil,
+    coalesce(miner_cron_fees.miner_cron_fee_assessed_fil, 0)
+        as miner_cron_fee_assessed_fil,
+    coalesce(miner_cron_fees.miner_cron_penalty_assessed_fil, 0)
+        as miner_cron_penalty_assessed_fil,
+    network_burn.total_burn_fil
+        - coalesce(network_activity.message_burn_fil, 0)
+        - coalesce(network_activity.message_miner_penalty_burn_fil, 0)
+        - coalesce(miner_cron_fees.miner_cron_burn_fil, 0)
+        as unattributed_burn_fil
+from raw.daily_network_burn as network_burn
+left join raw.daily_miner_cron_fees as miner_cron_fees
+    using (date)
+left join model.daily_network_activity as network_activity
+    using (date)
+order by date desc

--- a/assets/raw/daily/miner_cron_fees.sql
+++ b/assets/raw/daily/miner_cron_fees.sql
@@ -1,0 +1,25 @@
+-- asset.description = Daily Filecoin miner cron fees and penalties from Lily.
+-- asset.resource = bigquery.lily
+
+-- asset.column = date | UTC date.
+-- asset.column = miner_cron_burn_fil | FIL burned during miner cron events.
+-- asset.column = miner_cron_fee_assessed_fil | FIL fees assessed during miner cron events.
+-- asset.column = miner_cron_penalty_assessed_fil | FIL penalties assessed during miner cron events.
+
+-- asset.not_null = date
+-- asset.not_null = miner_cron_burn_fil
+-- asset.not_null = miner_cron_fee_assessed_fil
+-- asset.not_null = miner_cron_penalty_assessed_fil
+-- asset.unique = date
+
+select
+    date(timestamp_seconds((height * 30) + 1598306400)) as date,
+    cast(sum(cast(burn as bignumeric)) / 1e18 as float64)
+        as miner_cron_burn_fil,
+    cast(sum(cast(fee as bignumeric)) / 1e18 as float64)
+        as miner_cron_fee_assessed_fil,
+    cast(sum(cast(penalty as bignumeric)) / 1e18 as float64)
+        as miner_cron_penalty_assessed_fil
+from `miner_cron_fees`
+group by 1
+order by 1 desc

--- a/assets/raw/daily/network_activity_by_method.sql
+++ b/assets/raw/daily/network_activity_by_method.sql
@@ -26,6 +26,8 @@ select
             ) / 1e18
         ) as float64
     ) as message_burn_fil,
+    sum(cast(miner_penalty as float64) / 1e18)
+        as message_miner_penalty_burn_fil,
     cast(
         sum(
             (

--- a/assets/raw/daily/network_burn.sql
+++ b/assets/raw/daily/network_burn.sql
@@ -2,10 +2,10 @@
 -- asset.resource = bigquery.lily
 
 -- asset.column = date | UTC date.
--- asset.column = protocol_revenue_fil | Daily total FIL burned on-chain, in FIL.
+-- asset.column = total_burn_fil | Daily total FIL burned on-chain, in FIL.
 
 -- asset.not_null = date
--- asset.not_null = protocol_revenue_fil
+-- asset.not_null = total_burn_fil
 -- asset.unique = date
 
 with by_height as (
@@ -19,7 +19,7 @@ with by_height as (
 select
     date,
     cast(sum(burnt_fil - previous_burnt_fil) / 1e18 as float64)
-        as protocol_revenue_fil
+        as total_burn_fil
 from by_height
 where previous_burnt_fil is not null
 group by 1

--- a/web/scripts/datasets/filecoin-daily-metrics.ts
+++ b/web/scripts/datasets/filecoin-daily-metrics.ts
@@ -19,6 +19,7 @@ const SQL = `
     total_value_fil,
     total_value_flow_fil,
     protocol_revenue_fil,
+    message_miner_penalty_burn_fil,
     circulating_fil,
     locked_fil,
     burnt_fil,

--- a/web/src/pages/numbers.astro
+++ b/web/src/pages/numbers.astro
@@ -97,7 +97,7 @@ const sections = [
       {
         id: "revenue-coverage-ratio",
         title: "Revenue Coverage Ratio",
-        description: "Trailing-365-day protocol revenue divided by annual PGF deployments plus block reward issuance.",
+        description: "Trailing-365-day FIL burned divided by annual PGF deployments plus block reward issuance.",
         y: "revenue_coverage_ratio",
         format: "percent",
         details: {
@@ -105,7 +105,7 @@ const sections = [
             {
               id: "annual-protocol-revenue-usd",
               title: "Protocol Revenue",
-              description: "Sum of FIL burned times average FIL/USD price, trailing 365 days.",
+              description: "Total FIL burned over the trailing 365 days, valued at average FIL/USD price.",
               y: "annual_protocol_revenue_usd",
               format: "usd",
             },
@@ -246,15 +246,22 @@ const sections = [
     columns: 2,
     charts: [
       {
-        id: "daily-burnt-fil",
-        title: "Daily Burnt FIL",
-        description: "FIL burned on-chain per day.",
+        id: "daily-protocol-revenue-fil",
+        title: "Protocol Revenue FIL",
+        description: "Total FIL burned per day.",
         y: "protocol_revenue_fil",
         format: "fil",
       },
       {
+        id: "message-miner-penalty-burn-fil",
+        title: "Message Miner Penalty Burn",
+        description: "FIL burned by message execution miner penalties per day.",
+        y: "message_miner_penalty_burn_fil",
+        format: "fil",
+      },
+      {
         id: "total-burnt-fil",
-        title: "Total Burnt FIL",
+        title: "Total Burned FIL",
         description: "End-of-day cumulative FIL burned by the network.",
         y: "burnt_fil",
         format: "mfil",


### PR DESCRIPTION
Refines the network burn metric model and keeps the public numbers page change minimal.

Changes:
- Replaces the raw protocol revenue asset with `raw.daily_network_burn`.
- Adds `raw.daily_miner_cron_fees` and `model.daily_network_burn`.
- Renames burn fields to distinguish actual burns from cron fees and penalties assessed into miner debt.
- Exposes `message_miner_penalty_burn_fil` instead of the broader `miner_penalty_fil` in daily metrics and the numbers page.
- Simplifies annual protocol revenue calculations through an `annual_metrics` CTE.
- Standardizes metric copy on "burned".