### PR TITLE
🐛 Repair warm storage billing

### DIFF
--- a/assets/model/warm_storage/daily_activity.sql
+++ b/assets/model/warm_storage/daily_activity.sql
@@ -1,6 +1,7 @@
 -- asset.description = Daily warm storage activity.
 
 -- asset.depends = model.fevm_daily_checkpoints
+-- asset.depends = model.filecoin_pay_rail_rate_intervals
 -- asset.depends = model.warm_storage_datasets
 
 -- asset.column = date | UTC date.
@@ -16,21 +17,45 @@
 -- asset.not_null = new_datasets
 -- asset.unique = date
 
-with days as (
-    select date
+with dataset_intervals as (
+    select
+        datasets.dataset_id,
+        datasets.payer,
+        intervals.start_ordinal,
+        intervals.end_ordinal
+    from model.warm_storage_datasets as datasets
+    join model.filecoin_pay_rail_rate_intervals as intervals
+        on datasets.pdp_rail_id = intervals.rail_id
+    where intervals.rate_wei_per_epoch > 0
+),
+dataset_first_billing as (
+    select
+        dataset_id,
+        payer,
+        min(start_ordinal) as first_billing_ordinal
+    from dataset_intervals
+    group by 1, 2
+),
+dataset_first_billing_dates as (
+    select
+        first_billing.dataset_id,
+        first_billing.payer,
+        min(checkpoints.date) as first_billing_date
+    from dataset_first_billing as first_billing
+    join model.fevm_daily_checkpoints as checkpoints
+        on first_billing.first_billing_ordinal <= checkpoints.checkpoint_ordinal
+    group by 1, 2
+),
+days as (
+    select date, checkpoint_ordinal
     from model.fevm_daily_checkpoints
-    where date >= (
-        select min(date(billing_started_at))
-        from model.warm_storage_datasets
-        where billing_started_at is not null
-    )
+    where date >= (select min(first_billing_date) from dataset_first_billing_dates)
 ),
 payer_first_billing_dates as (
     select
         payer,
-        min(date(billing_started_at)) as first_billing_date
-    from model.warm_storage_datasets
-    where billing_started_at is not null
+        min(first_billing_date) as first_billing_date
+    from dataset_first_billing_dates
     group by 1
 ),
 new_payers as (
@@ -42,24 +67,31 @@ new_payers as (
 ),
 new_datasets as (
     select
-        date(billing_started_at) as date,
+        first_billing_date as date,
         count(*) as new_datasets
-    from model.warm_storage_datasets
-    where billing_started_at is not null
+    from dataset_first_billing_dates
+    group by 1
+),
+active_counts as (
+    select
+        days.date,
+        count(distinct intervals.payer) as active_payers,
+        count(distinct intervals.dataset_id) as active_datasets
+    from days
+    left join dataset_intervals as intervals
+        on intervals.start_ordinal <= days.checkpoint_ordinal
+       and coalesce(intervals.end_ordinal, 9223372036854775807) > days.checkpoint_ordinal
     group by 1
 )
 select
-    days.date,
-    count(distinct datasets.payer) as active_payers,
-    count(distinct datasets.dataset_id) as active_datasets,
+    active_counts.date,
+    active_counts.active_payers,
+    active_counts.active_datasets,
     coalesce(new_payers.new_payers, 0) as new_payers,
     coalesce(new_datasets.new_datasets, 0) as new_datasets
-from days
-left join model.warm_storage_datasets as datasets
-    on date(datasets.billing_started_at) <= days.date
-   and coalesce(date(datasets.billing_terminated_at), date '9999-12-31') > days.date
+from active_counts
 left join new_payers
     using (date)
 left join new_datasets
     using (date)
-group by 1, 4, 5
+order by date desc

--- a/assets/model/warm_storage/datasets.sql
+++ b/assets/model/warm_storage/datasets.sql
@@ -1,5 +1,6 @@
 -- asset.description = Warm storage datasets created onchain.
 
+-- asset.depends = model.filecoin_pay_rail_rate_intervals
 -- asset.depends = raw.fevm_eth_logs_decoded
 
 -- asset.column = dataset_id | FWSS dataset identifier.
@@ -48,13 +49,18 @@ dataset_created as (
 ),
 dataset_billing_started as (
     select
-        cast(json_extract_string(args, '$.dataSetId') as bigint) as dataset_id,
-        min(block_number) as billing_started_block
-    from raw.fevm_eth_logs_decoded
-    where contract_name = 'filecoin_warm_storage_service'
-      and event_name = 'RailRateUpdated'
-      and cast(json_extract_string(args, '$.newRate') as bigint) > 0
-    group by 1
+        created.dataset_id,
+        intervals.start_block as billing_started_block,
+        intervals.start_at as billing_started_at
+    from dataset_created as created
+    join model.filecoin_pay_rail_rate_intervals as intervals
+        on created.pdp_rail_id = intervals.rail_id
+    where created.row_num = 1
+      and intervals.rate_wei_per_epoch > 0
+    qualify row_number() over (
+        partition by created.dataset_id
+        order by intervals.start_ordinal
+    ) = 1
 ),
 dataset_billing_terminated as (
     select
@@ -89,10 +95,7 @@ select
     created.created_block,
     created.created_at,
     started.billing_started_block,
-    case
-        when started.billing_started_block is null then null
-        else to_timestamp(started.billing_started_block * 30 + (select genesis_timestamp from params))
-    end as billing_started_at,
+    started.billing_started_at,
     terminated.billing_terminated_block,
     case
         when terminated.billing_terminated_block is null then null


### PR DESCRIPTION
Repairs warm-storage billing and daily activity using the existing Filecoin Pay rail-rate intervals.

The decoded FWSS stream no longer contains `RailRateUpdated`, so the dataset model never found a positive billing start and the daily model remained empty.

- Derives each dataset's first billing start from its `pdp_rail_id` and first positive Filecoin Pay interval.
- Computes end-of-day active datasets and payers from positive half-open intervals, preserving zero-rate pauses and resumptions.
- Counts new datasets and payers only on their first positive interval.

Validation:

- `make check`
- `uv run --env-file .env fdp test` (81 passed)
- Materialized the affected model and public assets locally.
- Reconciled 1,274 billing starts across 1,312 datasets and 233 nonempty daily rows; the latest checkpoint has 619 active datasets and 100 active payers.
