### PR TITLE
🎨 Redesign dataset cards

### DIFF
--- a/web/scripts/stage-fdp-docs.ts
+++ b/web/scripts/stage-fdp-docs.ts
@@ -125,6 +125,48 @@ function parseAssetDoc(fileName: string, markdown: string): ParsedAssetDoc {
   return { title, description, codeUrl, body: withTables }
 }
 
+function renderDatasetSections(markdown: string): string {
+  const sections = markdown.match(/^## Columns\n\n([\s\S]*?)\n\n## Sample\n\n([\s\S]*)$/)
+  if (!sections) {
+    throw new Error("Expected Columns and Sample sections in generated dataset docs.")
+  }
+
+  const columnRows = sections[1].trim().split("\n")
+  if (columnRows.length < 3) {
+    throw new Error("Expected a columns table in generated dataset docs.")
+  }
+
+  const columns = columnRows.slice(2).map((row) => {
+    const cells = row.slice(1, -1).split("|").map((cell) => cell.trim())
+    if (cells.length !== 4) {
+      throw new Error(`Expected four cells in columns row: ${row}`)
+    }
+    return `| ${cells[0]} | ${cells[2]} |`
+  })
+
+  const columnsTable = [
+    "| name | description |",
+    "|---|---|",
+    ...columns,
+  ].join("\n")
+
+  return [
+    '<details class="dataset-section dataset-section--columns">',
+    "<summary>Columns</summary>",
+    "",
+    columnsTable,
+    "",
+    "</details>",
+    "",
+    '<details class="dataset-section dataset-section--sample">',
+    "<summary>Sample</summary>",
+    "",
+    sections[2].trim(),
+    "",
+    "</details>",
+  ].join("\n")
+}
+
 function renderCollectionDoc(parsed: ParsedAssetDoc): string {
   const frontmatter = [
     "---",
@@ -135,7 +177,7 @@ function renderCollectionDoc(parsed: ParsedAssetDoc): string {
     "",
   ].join("\n")
 
-  return `${frontmatter}${parsed.body.trim()}\n`
+  return `${frontmatter}${renderDatasetSections(parsed.body.trim())}\n`
 }
 
 async function syncDocs(sourceDir: string): Promise<void> {

--- a/web/src/pages/datasets.astro
+++ b/web/src/pages/datasets.astro
@@ -47,7 +47,7 @@ const datasets = await Promise.all(
 
         <div class="datasets-content">
           {datasets.map(({ id, title, description, downloadUrl, queryUrl, codeUrl, Content }) => (
-            <section class="dataset-entry" id={id}>
+            <section class="dataset-entry" id={id} aria-labelledby={`${id}-title`}>
               <header>
                 <div>
                   <h2 id={`${id}-title`}><a href={`#${id}`}>{title}</a></h2>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -928,10 +928,15 @@
     min-inline-size: 0;
   }
 
+  .dataset-entry {
+    scroll-margin-block-start: var(--space-4);
+    padding: var(--space-4);
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+  }
+
   .dataset-entry + .dataset-entry {
-    margin-block-start: var(--space-6);
-    padding-block-start: var(--space-6);
-    border-block-start: 1px solid var(--color-border);
+    margin-block-start: var(--space-4);
   }
 
   .dataset-entry > header {
@@ -983,8 +988,61 @@
     color: var(--color-text);
   }
 
-  .dataset-markdown > * + * {
-    margin-block-start: var(--space-4);
+  .dataset-markdown {
+    position: relative;
+    padding-block-start: 1.5rem;
+  }
+
+  .dataset-section summary {
+    position: absolute;
+    inset-block-start: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    inline-size: max-content;
+    padding: 0;
+    font-size: 0.85rem;
+    font-weight: 700;
+    cursor: pointer;
+    list-style: none;
+  }
+
+  .dataset-section--columns summary {
+    inset-inline-start: 0;
+  }
+
+  .dataset-section--sample summary {
+    inset-inline-start: 6.25rem;
+  }
+
+  .dataset-section summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .dataset-section summary::before {
+    content: "+";
+    font-size: 1.1rem;
+    font-weight: 400;
+    line-height: 1;
+  }
+
+  .dataset-section[open] summary::before {
+    content: "−";
+  }
+
+  .dataset-section summary:hover {
+    text-decoration: underline;
+    text-underline-offset: 0.16em;
+  }
+
+  .dataset-section summary:focus-visible {
+    outline: 2px solid var(--color-focus);
+    outline-offset: 3px;
+  }
+
+  .dataset-section > :not(summary) {
+    inline-size: 100%;
+    margin-block: var(--space-3) 0;
   }
 
   .dataset-markdown :where(p, ul, ol) {
@@ -1012,7 +1070,7 @@
   }
 
   .dataset-markdown :where(th, td) {
-    border: 1px solid var(--color-border);
+    border: 0;
     padding: var(--space-2) var(--space-3);
     text-align: left;
     vertical-align: top;
@@ -1020,6 +1078,21 @@
 
   .dataset-markdown :where(th) {
     background: var(--color-bg-muted);
+  }
+
+  .dataset-markdown :where(tbody tr:nth-child(even)) {
+    background: var(--color-bg-muted);
+  }
+
+  .dataset-section--columns :where(th:first-child, td:first-child) {
+    inline-size: 30%;
+    white-space: nowrap;
+  }
+
+  .dataset-section--columns :where(td:first-child code) {
+    background: transparent;
+    padding: 0;
+    font-weight: 700;
   }
 }
 


### PR DESCRIPTION
Render each dataset as a white card matching the Numbers page.

- Add compact inline disclosures for columns and samples
- Show only column names and descriptions
- Simplify expanded tables with borderless, alternating rows
- Associate cards with their headings for accessibility

Verified with `npm run check`, `npm run build`, and desktop/mobile screenshots.