### PR TITLE
✨ Publish network metrics as JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can run the Filecoin Data Portal anywhere using `uv`. You'll need the follow
 - `R2_BUCKET`
 - `FDP_GSHEET_SPREADSHEET_ID`
 
-`uv run fdp publish r2` writes one parquet file per `main.*` table to R2.
+`uv run fdp publish r2` writes one Parquet file per `main.*` table to R2 and serves compressed JSON for browser use at `https://data.filecoindataportal.xyz/daily_network_metrics.json.gz`.
 `uv run fdp publish gsheet` syncs one worksheet per `main.*` table to a Google spreadsheet and removes stale worksheets.
 Share the target spreadsheet with the Google service account from `ENCODED_GOOGLE_APPLICATION_CREDENTIALS`.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can run the Filecoin Data Portal anywhere using `uv`. You'll need the follow
 - `R2_BUCKET`
 - `FDP_GSHEET_SPREADSHEET_ID`
 
-`uv run fdp publish r2` writes one Parquet file per `main.*` table to R2 and serves compressed JSON for browser use at `https://data.filecoindataportal.xyz/daily_network_metrics.json.gz`.
+`uv run fdp publish r2` writes one Parquet file per `main.*` table to R2 and serves JSON for browser use at `https://data.filecoindataportal.xyz/daily_network_metrics.json`.
 `uv run fdp publish gsheet` syncs one worksheet per `main.*` table to a Google spreadsheet and removes stale worksheets.
 Share the target spreadsheet with the Google service account from `ENCODED_GOOGLE_APPLICATION_CREDENTIALS`.
 

--- a/fdp/targets/r2.py
+++ b/fdp/targets/r2.py
@@ -9,7 +9,6 @@ R2_ACCESS_KEY_ID_ENV_VAR = "R2_ACCESS_KEY_ID"
 R2_SECRET_ACCESS_KEY_ENV_VAR = "R2_SECRET_ACCESS_KEY"
 R2_ACCOUNT_ID_ENV_VAR = "R2_ACCOUNT_ID"
 R2_BUCKET_ENV_VAR = "R2_BUCKET"
-COMPRESSED_JSON_ASSET_KEY = "main.daily_network_metrics"
 
 
 @dataclass(frozen=True)
@@ -91,13 +90,15 @@ def publish_assets(
 
     for index, asset in enumerate(assets, start=1):
         filename, row_count, file_size_bytes = publish_asset(conn, asset, bucket)
-        filenames = [filename]
-        if asset.key == COMPRESSED_JSON_ASSET_KEY:
-            filenames.append(publish_compressed_json_asset(conn, asset, bucket))
+        if asset.key == "main.daily_network_metrics":
+            conn.execute(
+                f"copy (select * from {asset.key}) to ? (format json, array true)",
+                [f"r2://{bucket}/{asset.name}.json"],
+            )
         print(
             f"[{index:>{count_width}}/{total:>{count_width}}] "
             f"{asset.key:<{asset_width}} OK "
-            f"rows={row_count} bytes={file_size_bytes} {' '.join(filenames)}",
+            f"rows={row_count} bytes={file_size_bytes} {filename}",
             flush=True,
         )
 
@@ -115,7 +116,7 @@ def publish_asset(
         "row_group_size 1000000, "
         "return_stats"
         ")",
-        [r2_target_path(bucket, asset.name, "parquet")],
+        [r2_target_path(bucket, asset.name)],
     ).fetchone()
     if stats is None:
         raise RuntimeError(f"Publish returned no stats for {asset.key}")
@@ -124,19 +125,5 @@ def publish_asset(
     return str(filename), int(row_count), int(file_size_bytes)
 
 
-def publish_compressed_json_asset(
-    conn: duckdb.DuckDBPyConnection,
-    asset: Asset,
-    bucket: str,
-) -> str:
-    filename = r2_target_path(bucket, asset.name, "json.gz")
-    conn.execute(
-        f"copy (select * from {asset.key}) to ? "
-        "(format json, array true, compression gzip)",
-        [filename],
-    )
-    return filename
-
-
-def r2_target_path(bucket: str, table: str, extension: str) -> str:
-    return f"r2://{bucket}/{table}.{extension}"
+def r2_target_path(bucket: str, table: str) -> str:
+    return f"r2://{bucket}/{table}.parquet"

--- a/fdp/targets/r2.py
+++ b/fdp/targets/r2.py
@@ -9,6 +9,7 @@ R2_ACCESS_KEY_ID_ENV_VAR = "R2_ACCESS_KEY_ID"
 R2_SECRET_ACCESS_KEY_ENV_VAR = "R2_SECRET_ACCESS_KEY"
 R2_ACCOUNT_ID_ENV_VAR = "R2_ACCOUNT_ID"
 R2_BUCKET_ENV_VAR = "R2_BUCKET"
+COMPRESSED_JSON_ASSET_KEY = "main.daily_network_metrics"
 
 
 @dataclass(frozen=True)
@@ -90,10 +91,13 @@ def publish_assets(
 
     for index, asset in enumerate(assets, start=1):
         filename, row_count, file_size_bytes = publish_asset(conn, asset, bucket)
+        filenames = [filename]
+        if asset.key == COMPRESSED_JSON_ASSET_KEY:
+            filenames.append(publish_compressed_json_asset(conn, asset, bucket))
         print(
             f"[{index:>{count_width}}/{total:>{count_width}}] "
             f"{asset.key:<{asset_width}} OK "
-            f"rows={row_count} bytes={file_size_bytes} {filename}",
+            f"rows={row_count} bytes={file_size_bytes} {' '.join(filenames)}",
             flush=True,
         )
 
@@ -111,7 +115,7 @@ def publish_asset(
         "row_group_size 1000000, "
         "return_stats"
         ")",
-        [r2_target_path(bucket, asset.name)],
+        [r2_target_path(bucket, asset.name, "parquet")],
     ).fetchone()
     if stats is None:
         raise RuntimeError(f"Publish returned no stats for {asset.key}")
@@ -120,5 +124,19 @@ def publish_asset(
     return str(filename), int(row_count), int(file_size_bytes)
 
 
-def r2_target_path(bucket: str, table: str) -> str:
-    return f"r2://{bucket}/{table}.parquet"
+def publish_compressed_json_asset(
+    conn: duckdb.DuckDBPyConnection,
+    asset: Asset,
+    bucket: str,
+) -> str:
+    filename = r2_target_path(bucket, asset.name, "json.gz")
+    conn.execute(
+        f"copy (select * from {asset.key}) to ? "
+        "(format json, array true, compression gzip)",
+        [filename],
+    )
+    return filename
+
+
+def r2_target_path(bucket: str, table: str, extension: str) -> str:
+    return f"r2://{bucket}/{table}.{extension}"

--- a/fdp/templates/SKILL.md
+++ b/fdp/templates/SKILL.md
@@ -38,7 +38,7 @@ Ask a clarification question only if the relevant dataset or metric remains ambi
 2. Mention and link the relevant datasets used and display `filecoindataportal.xyz` as the source.
 3. Serve it locally and share the URL.
 
-**Note:** _The `daily_network_metrics` dataset/table is also available as an all-column gzip-compressed JSON array at `{{ public_datasets_base_url }}/daily_network_metrics.json.gz`. Load it directly from the HTML so dashboards/charts are always up to date if the user asks for live dashboards, self-updating charts, ...
+**Note:** _The `daily_network_metrics` dataset/table is also available as an all-column JSON array at `{{ public_datasets_base_url }}/daily_network_metrics.json`. Load it directly from the HTML so dashboards/charts are always up to date if the user asks for live dashboards, self-updating charts, ...
 
 ## Feedback
 

--- a/fdp/templates/SKILL.md
+++ b/fdp/templates/SKILL.md
@@ -38,6 +38,8 @@ Ask a clarification question only if the relevant dataset or metric remains ambi
 2. Mention and link the relevant datasets used and display `filecoindataportal.xyz` as the source.
 3. Serve it locally and share the URL.
 
+**Note:** _The `daily_network_metrics` dataset/table is also available as an all-column gzip-compressed JSON array at `{{ public_datasets_base_url }}/daily_network_metrics.json.gz`. Load it directly from the HTML so dashboards/charts are always up to date if the user asks for live dashboards, self-updating charts, ...
+
 ## Feedback
 
 If you find datasets, docs, metrics, or model derivations are wrong, confusing, stale, missing, or useful, offer to open a GitHub issue:


### PR DESCRIPTION
Publishes `main.daily_network_metrics` as JSON alongside the existing Parquet export. Documents the public URL and directs generated data portal skills to use it for live dashboards.

`make check` passes.