### PR TITLE
✨ Add chart question prompts

### DIFF
--- a/web/src/components/StatCard.astro
+++ b/web/src/components/StatCard.astro
@@ -63,9 +63,20 @@ const chartSummaryId = `${id}-chart-summary`
           aria-label={`About ${title}`}
           aria-describedby={tooltipId}
         >
-          i
+          ?
         </button>
-        <span id={tooltipId} class="stat-card__info-tooltip" role="tooltip">{description}</span>
+        <span class="stat-card__info-tooltip">
+          <span id={tooltipId}>{description}</span>
+          <button
+            type="button"
+            class="stat-card__copy-prompt"
+            data-chart-copy-prompt
+            aria-label={`Copy agent prompt about ${title}`}
+          >
+            Ask your agent
+          </button>
+          <span class="stat-card__prompt-status" data-chart-prompt-status role="status"></span>
+        </span>
       </span>
       <button
         type="button"
@@ -78,7 +89,7 @@ const chartSummaryId = `${id}-chart-summary`
           <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
         </svg>
       </button>
-      <span class="visually-hidden" data-chart-copy-status role="status"></span>
+      <span class="visually-hidden" data-chart-link-status role="status"></span>
     </span>
     <button
       type="button"

--- a/web/src/pages/numbers.astro
+++ b/web/src/pages/numbers.astro
@@ -671,7 +671,9 @@ function metricSummary(metric: NumbersMetric): MetricSummary {
       panel: HTMLElement
       canvas: HTMLElement
       copyLink: HTMLButtonElement
-      copyStatus: HTMLElement
+      copyPrompt: HTMLButtonElement
+      linkStatus: HTMLElement
+      promptStatus: HTMLElement
       copyResetTimer?: number
       toggle: HTMLButtonElement
       status: HTMLElement
@@ -850,7 +852,9 @@ function metricSummary(metric: NumbersMetric): MetricSummary {
         panel,
         canvas: requiredElement(panel, ":scope > [data-chart-canvas]", "a chart"),
         copyLink: requiredElement(node, "[data-chart-copy-link]", "a copy link button"),
-        copyStatus: requiredElement(node, "[data-chart-copy-status]", "a copy link status"),
+        copyPrompt: requiredElement(node, "[data-chart-copy-prompt]", "a copy prompt button"),
+        linkStatus: requiredElement(node, "[data-chart-link-status]", "a copy link status"),
+        promptStatus: requiredElement(node, "[data-chart-prompt-status]", "a copy prompt status"),
         toggle: requiredElement(node, "[data-chart-toggle]", "an expand button"),
         status: requiredElement(panel, "[data-chart-status]", "a chart status"),
         sparkline,
@@ -1271,18 +1275,38 @@ function metricSummary(metric: NumbersMetric): MetricSummary {
       })
     }
 
-    function showCopyFeedback(card: CardView, message: string, copied: boolean): void {
-      if (card.copyResetTimer) window.clearTimeout(card.copyResetTimer)
+    function resetCopyFeedback(card: CardView): void {
+      card.linkStatus.textContent = ""
+      card.promptStatus.textContent = ""
+      card.copyLink.classList.remove("is-copied")
+      card.copyLink.setAttribute("aria-label", `Copy link to ${card.title}`)
+      card.copyPrompt.classList.remove("is-copied")
+      card.copyPrompt.setAttribute("aria-label", `Copy agent prompt about ${card.title}`)
+    }
 
-      card.copyStatus.textContent = message
-      card.copyLink.classList.toggle("is-copied", copied)
-      card.copyLink.setAttribute("aria-label", message)
+    function showCopyFeedback(
+      card: CardView,
+      button: HTMLButtonElement,
+      status: HTMLElement,
+      message: string,
+      copied: boolean,
+    ): void {
+      if (card.copyResetTimer) window.clearTimeout(card.copyResetTimer)
+      resetCopyFeedback(card)
+
+      status.textContent = message
+      button.classList.toggle("is-copied", copied)
+      button.setAttribute("aria-label", message)
       card.copyResetTimer = window.setTimeout(() => {
-        card.copyStatus.textContent = ""
-        card.copyLink.classList.remove("is-copied")
-        card.copyLink.setAttribute("aria-label", `Copy link to ${card.title}`)
+        resetCopyFeedback(card)
         card.copyResetTimer = undefined
-      }, 2_000)
+      }, 4_000)
+    }
+
+    function cardUrl(card: CardView): URL {
+      const url = new URL(window.location.href)
+      url.hash = card.id
+      return url
     }
 
     async function copyCardLink(card: CardView): Promise<void> {
@@ -1290,15 +1314,61 @@ function metricSummary(metric: NumbersMetric): MetricSummary {
         throw new Error("Clipboard API is unavailable")
       }
 
-      const url = new URL(window.location.href)
-      url.hash = card.id
-      await navigator.clipboard.writeText(url.toString())
-      showCopyFeedback(card, `Link copied for ${card.title}`, true)
+      await navigator.clipboard.writeText(cardUrl(card).toString())
+      showCopyFeedback(
+        card,
+        card.copyLink,
+        card.linkStatus,
+        `Link copied for ${card.title}`,
+        true,
+      )
     }
 
     function requestCopyCardLink(card: CardView): void {
       void copyCardLink(card).catch((error: unknown) => {
-        showCopyFeedback(card, `Could not copy link to ${card.title}`, false)
+        showCopyFeedback(
+          card,
+          card.copyLink,
+          card.linkStatus,
+          `Could not copy link to ${card.title}`,
+          false,
+        )
+        console.error(error)
+      })
+    }
+
+    async function copyCardPrompt(card: CardView): Promise<void> {
+      if (typeof navigator.clipboard?.writeText !== "function") {
+        throw new Error("Clipboard API is unavailable")
+      }
+
+      const columns = [...new Set([
+        card.config.y,
+        ...(card.config.series?.map(({ y }) => y) ?? []),
+        ...card.details.map(({ config }) => config.y),
+      ])]
+      const source = columns.map((column) => `daily_network_metrics.${column}`).join(", ")
+      const prompt = `Read https://filecoindataportal.xyz/SKILL.md and get the definition, model and upstream assets, and data sample for the "${card.title}" chart at ${cardUrl(card)}. Source columns: ${source}. Then answer the following question:\n\n`
+
+      await navigator.clipboard.writeText(prompt)
+      showCopyFeedback(
+        card,
+        card.copyPrompt,
+        card.promptStatus,
+        "Copied! Paste it into your agent.",
+        true,
+      )
+    }
+
+    function requestCopyCardPrompt(card: CardView): void {
+      void copyCardPrompt(card).catch((error: unknown) => {
+        showCopyFeedback(
+          card,
+          card.copyPrompt,
+          card.promptStatus,
+          `Could not copy prompt for ${card.title}`,
+          false,
+        )
         console.error(error)
       })
     }
@@ -1382,6 +1452,10 @@ function metricSummary(metric: NumbersMetric): MetricSummary {
 
       card.copyLink.addEventListener("click", () => {
         requestCopyCardLink(card)
+      })
+
+      card.copyPrompt.addEventListener("click", () => {
+        requestCopyCardPrompt(card)
       })
     }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -753,9 +753,39 @@
     text-align: start;
   }
 
+  .stat-card__copy-prompt {
+    justify-self: start;
+    padding: var(--space-1) var(--space-2);
+    border: 1px solid var(--color-border-strong);
+    background: var(--color-text);
+    color: var(--color-bg);
+    font: inherit;
+    font-size: 0.72rem;
+    font-weight: 700;
+    line-height: 1.4;
+    text-transform: uppercase;
+    cursor: copy;
+  }
+
+  .stat-card__copy-prompt:hover,
+  .stat-card__copy-prompt:focus-visible {
+    background: var(--color-surface);
+    color: var(--color-text);
+  }
+
+  .stat-card__prompt-status {
+    color: var(--color-text);
+    font-weight: 700;
+  }
+
+  .stat-card__prompt-status:empty {
+    display: none;
+  }
+
   .stat-card__info-wrap:hover .stat-card__info-tooltip,
   .stat-card__info-wrap:focus-within .stat-card__info-tooltip {
-    display: block;
+    display: grid;
+    gap: var(--space-2);
   }
 
   .stat-card.is-expanded {


### PR DESCRIPTION
Adds an “Ask your agent” action to each chart help popover. It copies a portable prompt with the portal skill, chart deep link, source columns, and instructions to inspect the definition, model and upstream assets, and a data sample.

Shows clear clipboard feedback directing users to paste the prompt into their agent.