### PR TITLE
💚 Isolate Google Sheets publishing

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,7 +19,6 @@ jobs:
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_BUCKET: ${{ secrets.R2_BUCKET }}
-      FDP_GSHEET_SPREADSHEET_ID: ${{ secrets.FDP_GSHEET_SPREADSHEET_ID }}
       OSO_API_KEY: ${{ secrets.OSO_API_KEY }}
       FDP_FILECOIN_RPC_MAX_CONCURRENT: 1
 
@@ -69,12 +68,36 @@ jobs:
       - name: Publish to R2
         run: uv run fdp publish r2
 
-      - name: Publish to Google Sheets
-        run: uv run fdp publish gsheet
-
       - name: Save DuckDB cache
         if: success()
         uses: actions/cache/save@v5
         with:
           path: fdp.duckdb
           key: duckdb-${{ github.ref_name }}-${{ github.run_id }}
+
+  google-sheets:
+    name: Google Sheets
+    needs: pipeline
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    env:
+      ENCODED_GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.ENCODED_GOOGLE_APPLICATION_CREDENTIALS }}
+      FDP_GSHEET_SPREADSHEET_ID: ${{ secrets.FDP_GSHEET_SPREADSHEET_ID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Restore DuckDB cache
+        uses: actions/cache/restore@v5
+        with:
+          path: fdp.duckdb
+          key: duckdb-${{ github.ref_name }}-${{ github.run_id }}
+          fail-on-cache-miss: true
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Publish to Google Sheets
+        run: uv run fdp publish gsheet


### PR DESCRIPTION
Moves Google Sheets publishing into a separate, non-blocking job that restores the run-specific DuckDB cache.

The primary pipeline now publishes R2 and saves its cache independently, so transient Google Sheets failures no longer fail the workflow or suppress the website deployment.