### PR TITLE
🏷️ Label FIL One Storage operator in Filecoin Pay rails

### DIFF
--- a/assets/model/filecoin_pay/rails.sql
+++ b/assets/model/filecoin_pay/rails.sql
@@ -35,7 +35,8 @@ with params as (
     select
         1598306400 as genesis_timestamp,
         '0xa5f90bc2aa73a2e0bad4d7092a932644d5dd5d71' as dealbot_payer,
-        '0x56e53c5e7f27504b810494cc3b88b2aa0645a839' as storacha_operator
+        '0x56e53c5e7f27504b810494cc3b88b2aa0645a839' as storacha_operator,
+        '0x9d4f07b948e87941a4bf4ab335d7a7d854843d75' as fil_one_operator
 ),
 tokens as (
     select
@@ -101,6 +102,7 @@ select
     created.operator,
     case
         when created.operator = (select storacha_operator from params) then 'Storacha'
+        when created.operator = (select fil_one_operator from params) then 'FIL One Storage'
         else 'FWSS'
     end as service,
     created.validator,


### PR DESCRIPTION
Rails created by the FIL One Storage operator contract (0x9D4f07b948E87941a4Bf4Ab335d7A7d854843d75) are currently classified under the FWSS fallback in the service column. This adds the operator to the params CTE and the service case expression so FIL One rails are labeled 'FIL One Storage'.

The operator contract is Sourcify-verified on Filecoin mainnet and implements IFilecoinServiceMetadata; name() returns "FIL One Storage". Context: FIL One (Filecoin Foundation's storage subsidiary) pays Aurora Infrastructure EU under a storage MSA on rail 2570 — briefed via Slack DM this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)