### PR TITLE
🔥 Remove deprecated Dune references

### DIFF
--- a/web/src/pages/about.astro
+++ b/web/src/pages/about.astro
@@ -50,9 +50,6 @@ import Layout from "../layouts/Layout.astro"
           <a href="/numbers">Filecoin In Numbers</a>.
         </li>
         <li>
-          <a href="https://dune.com/kalen/filecoin-daily-metrics">Dune Dashboard</a>.
-        </li>
-        <li>
           <a href="https://www.reppo.ai/models"
             >Reppo Storage Provider reputation models</a
           >.

--- a/web/src/pages/docs.astro
+++ b/web/src/pages/docs.astro
@@ -259,16 +259,6 @@ import Layout from "../layouts/Layout.astro"
         > to see how to explore and visualize the datasets.
     </p>
 
-    <h3>Dune</h3>
-
-    <p>
-        Some of the datasets built by the pipelines are also available in Dune.
-        You can use the Dune SQL editor to run queries on these datasets. <a
-            href="https://dune.com/queries/3302707/5958324"
-            >Check this one on Dune</a
-        >.
-    </p>
-
     <h3>Google Sheets</h3>
 
     <p>

--- a/web/src/pages/index.astro
+++ b/web/src/pages/index.astro
@@ -58,7 +58,6 @@ import Layout from "../layouts/Layout.astro"
     </p>
     <ul>
       <li><a href="/numbers">Filecoin In Numbers</a> — core network metrics with a rich chart set.</li>
-      <li><a href="https://dune.com/kalen/filecoin-daily-metrics" target="_blank" rel="noopener noreferrer">Dune Filecoin Metrics</a> — SQL based exploration in Dune Analytics.</li>
       <li><a href="https://filecoin-project.github.io/filecoin-storage-providers-market/" target="_blank" rel="noopener noreferrer">Storage Providers Market</a> — market between Clients and Providers.</li>
     </ul>
   </section>


### PR DESCRIPTION
Removes the deprecated dashboard from the homepage and About page, and deletes its usage section from the documentation.