### PR TITLE
🐛 Increase CDP allocators timeout

### DIFF
--- a/assets/raw/cdp/allocators.py
+++ b/assets/raw/cdp/allocators.py
@@ -111,7 +111,7 @@ COLUMNS = (
 
 
 def allocators() -> pl.DataFrame:
-    data = httpx.get(URL, follow_redirects=True, timeout=30).raise_for_status().json()
+    data = httpx.get(URL, follow_redirects=True, timeout=60).raise_for_status().json()
     return (
         pl
         .DataFrame(data["data"], infer_schema_length=None, strict=False)


### PR DESCRIPTION
## Summary

- increase the CDP allocators request timeout from 30 to 60 seconds

## Context

Pipeline run [#703](https://github.com/davidgasquez/filecoin-data-portal/actions/runs/33661636041/job/100353316883) failed while materializing `raw.cdp_allocators` because the upstream response exceeded the existing 30-second read timeout.

## Validation

- `uv run ruff check fdp assets`
- `uv run ty check fdp assets`
- `uv run fdp check`

A live local materialization could not be completed because the workspace's configured SOCKS proxy is unavailable to HTTPX; CI will exercise the upstream request.