### PR TITLE
🐛 Increase CDP clients timeout

### DIFF
--- a/assets/raw/cdp/clients.py
+++ b/assets/raw/cdp/clients.py
@@ -41,7 +41,7 @@ COLUMNS = (
 
 
 def clients() -> pl.DataFrame:
-    data = httpx.get(URL, follow_redirects=True, timeout=30).raise_for_status().json()
+    data = httpx.get(URL, follow_redirects=True, timeout=60).raise_for_status().json()
     return (
         pl
         .DataFrame(data["data"], infer_schema_length=None, strict=False)


### PR DESCRIPTION
## Summary

- increase the CDP clients request timeout from 30 to 60 seconds

## Context

Pipeline run [#704](https://github.com/davidgasquez/filecoin-data-portal/actions/runs/33665835986/job/100367235391) failed while materializing `raw.cdp_clients` because the upstream response exceeded the existing 30-second read timeout.

This mirrors the allocator timeout adjustment from #292.